### PR TITLE
Organise imports

### DIFF
--- a/ui/lib/app_state.dart
+++ b/ui/lib/app_state.dart
@@ -1,3 +1,4 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
 
 class AppState extends ChangeNotifier {

--- a/ui/lib/components/app_bar/logout_button.dart
+++ b/ui/lib/components/app_bar/logout_button.dart
@@ -1,5 +1,10 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:provider/provider.dart';
+
+// Project imports:
 import 'package:ui/app_state.dart';
 
 class LogoutButton extends StatelessWidget {

--- a/ui/lib/components/app_bar/settings_dialog.dart
+++ b/ui/lib/components/app_bar/settings_dialog.dart
@@ -1,3 +1,4 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
 
 class SettingsDialog extends StatelessWidget {

--- a/ui/lib/components/messages/message_container.dart
+++ b/ui/lib/components/messages/message_container.dart
@@ -1,3 +1,4 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
 
 class MessageContainer extends StatelessWidget {

--- a/ui/lib/components/messages/message_input.dart
+++ b/ui/lib/components/messages/message_input.dart
@@ -1,5 +1,8 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
-import '../../helpers/http_helper.dart';
+
+// Project imports:
+import 'package:ui/helpers/http_helper.dart';
 
 class MessageInput extends StatefulWidget {
   final VoidCallback onSend;

--- a/ui/lib/components/messages/message_list.dart
+++ b/ui/lib/components/messages/message_list.dart
@@ -1,5 +1,8 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
-import 'message_container.dart';
+
+// Project imports:
+import 'package:ui/components/messages/message_container.dart';
 
 class MessageList extends StatefulWidget {
   final List<Map<String, dynamic>> messages;

--- a/ui/lib/helpers/http_helper.dart
+++ b/ui/lib/helpers/http_helper.dart
@@ -1,9 +1,16 @@
-import 'package:http/http.dart' as http;
-import 'package:provider/provider.dart';
-import 'package:flutter/material.dart';
-import 'package:ui/app_state.dart';
+// Dart imports:
 import 'dart:convert';
 import 'dart:io';
+
+// Flutter imports:
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:http/http.dart' as http;
+import 'package:provider/provider.dart';
+
+// Project imports:
+import 'package:ui/app_state.dart';
 
 class HttpHelper {
   final http.Client client;

--- a/ui/lib/main.dart
+++ b/ui/lib/main.dart
@@ -1,7 +1,12 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:provider/provider.dart';
-import 'app_state.dart';
+
+// Project imports:
 import 'package:ui/pages/home_page.dart';
+import 'package:ui/app_state.dart';
 
 void main() {
   runApp(

--- a/ui/lib/pages/home_page.dart
+++ b/ui/lib/pages/home_page.dart
@@ -1,13 +1,20 @@
+// Dart imports:
+import 'dart:async';
+
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
+
+// Project imports:
 import 'package:ui/app_state.dart';
+import 'package:ui/components/app_bar/logout_button.dart';
 import 'package:ui/components/app_bar/settings_dialog.dart';
 import 'package:ui/helpers/http_helper.dart';
 import 'package:ui/pages/login_page.dart';
 import 'package:ui/pages/message_page.dart';
-import 'dart:async';
-import 'package:http/http.dart' as http;
-import 'package:ui/components/app_bar/logout_button.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});

--- a/ui/lib/pages/login_page.dart
+++ b/ui/lib/pages/login_page.dart
@@ -1,9 +1,14 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
+// Package imports:
+import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
+
+// Project imports:
 import 'package:ui/app_state.dart';
 import 'package:ui/helpers/http_helper.dart';
-import 'package:http/http.dart' as http;
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});

--- a/ui/lib/pages/message_page.dart
+++ b/ui/lib/pages/message_page.dart
@@ -1,10 +1,15 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+
+// Package imports:
 import 'package:http/http.dart' as http;
-import '../components/messages/message_input.dart';
-import '../components/messages/message_list.dart';
-import '../app_state.dart';
-import '../helpers/http_helper.dart';
+import 'package:provider/provider.dart';
+
+// Project imports:
+import 'package:ui/app_state.dart';
+import 'package:ui/components/messages/message_input.dart';
+import 'package:ui/components/messages/message_list.dart';
+import 'package:ui/helpers/http_helper.dart';
 
 class MessagePage extends StatefulWidget {
   const MessagePage({super.key});

--- a/ui/pubspec.lock
+++ b/ui/pubspec.lock
@@ -267,6 +267,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  import_sorter:
+    dependency: "direct dev"
+    description:
+      name: import_sorter
+      sha256: eb15738ccead84e62c31e0208ea4e3104415efcd4972b86906ca64a1187d0836
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
   io:
     dependency: transitive
     description:
@@ -496,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  tint:
+    dependency: transitive
+    description:
+      name: tint
+      sha256: "9652d9a589f4536d5e392cf790263d120474f15da3cf1bee7f1fdb31b4de5f46"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:

--- a/ui/pubspec.yaml
+++ b/ui/pubspec.yaml
@@ -50,6 +50,7 @@ dev_dependencies:
   flutter_lints: ^2.0.0
   mockito: ^5.0.15
   build_runner: ^2.1.7
+  import_sorter: ^4.6.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/ui/test/app_state_test.dart
+++ b/ui/test/app_state_test.dart
@@ -1,4 +1,7 @@
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
 import 'package:ui/app_state.dart';
 
 void main() {

--- a/ui/test/components/app_bar/logout_button_test.dart
+++ b/ui/test/components/app_bar/logout_button_test.dart
@@ -1,6 +1,11 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
+
+// Project imports:
 import 'package:ui/app_state.dart';
 import 'package:ui/components/app_bar/logout_button.dart';
 

--- a/ui/test/components/app_bar/settings_dialog_test.dart
+++ b/ui/test/components/app_bar/settings_dialog_test.dart
@@ -1,5 +1,10 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
 import 'package:ui/components/app_bar/settings_dialog.dart';
 
 void main() {

--- a/ui/test/components/messages/message_container_test.dart
+++ b/ui/test/components/messages/message_container_test.dart
@@ -1,5 +1,10 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
 import 'package:ui/components/messages/message_container.dart';
 
 void main() {

--- a/ui/test/components/messages/message_list_test.dart
+++ b/ui/test/components/messages/message_list_test.dart
@@ -1,5 +1,10 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
 import 'package:ui/components/messages/message_list.dart';
 
 void main() {

--- a/ui/test/helpers/http_helper_test.dart
+++ b/ui/test/helpers/http_helper_test.dart
@@ -1,13 +1,20 @@
+// Dart imports:
+import 'dart:convert';
+
+// Flutter imports:
+import 'package:flutter/widgets.dart';
+
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'dart:convert';
-import 'package:ui/helpers/http_helper.dart';
-import 'package:ui/app_state.dart';
-import 'http_helper_test.mocks.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter/widgets.dart';
+
+// Project imports:
+import 'package:ui/app_state.dart';
+import 'package:ui/helpers/http_helper.dart';
+import 'http_helper_test.mocks.dart';
 
 // Generate a MockClient using the Mockito package.
 // Create new instances of this class in each test.

--- a/ui/test/helpers/http_helper_test.mocks.dart
+++ b/ui/test/helpers/http_helper_test.mocks.dart
@@ -3,10 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+// Dart imports:
 import 'dart:async' as _i3;
 import 'dart:convert' as _i4;
 import 'dart:typed_data' as _i6;
 
+// Package imports:
 import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i5;

--- a/ui/test/pages/home_page_test.dart
+++ b/ui/test/pages/home_page_test.dart
@@ -1,13 +1,18 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
-import 'package:ui/pages/home_page.dart';
-import 'package:ui/app_state.dart';
-import 'package:ui/components/app_bar/settings_dialog.dart';
-import 'package:ui/helpers/http_helper.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/annotations.dart';
+import 'package:provider/provider.dart';
+
+// Project imports:
+import 'package:ui/app_state.dart';
 import 'package:ui/components/app_bar/logout_button.dart';
+import 'package:ui/components/app_bar/settings_dialog.dart';
+import 'package:ui/helpers/http_helper.dart';
+import 'package:ui/pages/home_page.dart';
 
 @GenerateMocks([HttpHelper, http.Client])
 void main() {

--- a/ui/test/pages/home_page_test.mocks.dart
+++ b/ui/test/pages/home_page_test.mocks.dart
@@ -3,14 +3,21 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+// Dart imports:
 import 'dart:async' as _i4;
 import 'dart:convert' as _i6;
 import 'dart:typed_data' as _i8;
 
+// Flutter imports:
 import 'package:flutter/material.dart' as _i5;
+
+// Package imports:
 import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i7;
+
+// Project imports:
 import 'package:ui/helpers/http_helper.dart' as _i3;
 
 // ignore_for_file: type=lint

--- a/ui/test/pages/login_page_test.dart
+++ b/ui/test/pages/login_page_test.dart
@@ -1,11 +1,16 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
-import 'package:ui/app_state.dart';
-import 'package:ui/pages/login_page.dart';
-import 'package:ui/helpers/http_helper.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/annotations.dart';
+import 'package:provider/provider.dart';
+
+// Project imports:
+import 'package:ui/app_state.dart';
+import 'package:ui/helpers/http_helper.dart';
+import 'package:ui/pages/login_page.dart';
 import 'login_page_test.mocks.dart';
 
 @GenerateMocks([HttpHelper, http.Client])

--- a/ui/test/pages/login_page_test.mocks.dart
+++ b/ui/test/pages/login_page_test.mocks.dart
@@ -3,14 +3,21 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+// Dart imports:
 import 'dart:async' as _i4;
 import 'dart:convert' as _i6;
 import 'dart:typed_data' as _i8;
 
+// Flutter imports:
 import 'package:flutter/material.dart' as _i5;
+
+// Package imports:
 import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i7;
+
+// Project imports:
 import 'package:ui/helpers/http_helper.dart' as _i3;
 
 // ignore_for_file: type=lint

--- a/ui/test/pages/message_page_test.dart
+++ b/ui/test/pages/message_page_test.dart
@@ -1,13 +1,18 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
-import 'package:ui/components/messages/message_input.dart';
-import 'package:ui/components/messages/message_list.dart';
-import 'package:ui/pages/message_page.dart';
-import 'package:ui/app_state.dart';
-import 'package:ui/helpers/http_helper.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/annotations.dart';
+import 'package:provider/provider.dart';
+
+// Project imports:
+import 'package:ui/app_state.dart';
+import 'package:ui/components/messages/message_input.dart';
+import 'package:ui/components/messages/message_list.dart';
+import 'package:ui/helpers/http_helper.dart';
+import 'package:ui/pages/message_page.dart';
 
 @GenerateMocks([HttpHelper, http.Client])
 void main() {

--- a/ui/test/pages/message_page_test.mocks.dart
+++ b/ui/test/pages/message_page_test.mocks.dart
@@ -3,14 +3,21 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
+// Dart imports:
 import 'dart:async' as _i4;
 import 'dart:convert' as _i6;
 import 'dart:typed_data' as _i8;
 
+// Flutter imports:
 import 'package:flutter/material.dart' as _i5;
+
+// Package imports:
 import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i7;
+
+// Project imports:
 import 'package:ui/helpers/http_helper.dart' as _i3;
 
 // ignore_for_file: type=lint


### PR DESCRIPTION
This pull request focuses on organizing import statements across various files in the project to improve code readability and maintainability. The changes include categorizing imports into Dart, Flutter, package, and project imports, and adding a new dependency to the `pubspec.yaml` file for automated import sorting.