### PR TITLE
Add test code coverage and upload report

### DIFF
--- a/.github/workflows/ci_ui.yml
+++ b/.github/workflows/ci_ui.yml
@@ -31,7 +31,11 @@ jobs:
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-pub-
-      - name: Install dependencies
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install lcov
+      - name: Install Flutter dependencies
         run: |
           cd ui
           flutter pub get

--- a/.github/workflows/ci_ui.yml
+++ b/.github/workflows/ci_ui.yml
@@ -38,4 +38,13 @@ jobs:
       - name: Test with flutter test
         run: |
           cd ui
-          flutter test
+          flutter test --coverage
+      - name: Generate coverage report
+        run: |
+          cd ui
+          genhtml coverage/lcov.info -o coverage/html
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: ui/coverage/html

--- a/ui/test/components/app_bar/settings_dialog_test.dart
+++ b/ui/test/components/app_bar/settings_dialog_test.dart
@@ -38,4 +38,20 @@ void main() {
 
     expect(find.byType(AlertDialog), findsNothing);
   });
+
+  testWidgets('SettingsButton opens SettingsDialog',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SettingsButton(),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(SettingsButton));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SettingsDialog), findsOneWidget);
+  });
 }

--- a/ui/test/pages/home_page_test.dart
+++ b/ui/test/pages/home_page_test.dart
@@ -42,6 +42,17 @@ void main() {
     expect(find.byType(SettingsButton), findsOneWidget);
   });
 
+  testWidgets('SettingsButton opens SettingsDialog',
+      (WidgetTester tester) async {
+    final appState = AppState();
+    appState.setActivePage('message');
+    await tester.pumpWidget(createHomePage(appState));
+
+    await tester.tap(find.byType(SettingsButton));
+    await tester.pumpAndSettle();
+    expect(find.byType(SettingsDialog), findsOneWidget);
+  });
+
   testWidgets('HomePage does not display SettingsButton on login page',
       (WidgetTester tester) async {
     final appState = AppState();
@@ -55,5 +66,13 @@ void main() {
     appState.setActivePage('message');
     await tester.pumpWidget(createHomePage(appState));
     expect(find.byType(LogoutButton), findsOneWidget);
+  });
+
+  testWidgets('HomePage does not display LogoutButton on login page',
+      (WidgetTester tester) async {
+    final appState = AppState();
+    appState.setActivePage('login');
+    await tester.pumpWidget(createHomePage(appState));
+    expect(find.byType(LogoutButton), findsNothing);
   });
 }


### PR DESCRIPTION
This pull request includes changes to the continuous integration workflow to add code coverage reporting for the UI tests. The most important changes involve modifying the test command to include coverage, generating the coverage report, and uploading the report as an artifact.

Enhancements to CI workflow:

* [`.github/workflows/ci_ui.yml`](diffhunk://#diff-70c49855b7345815ea1d055dcb6de8f819a4654a6f651bea50dd87979d22fc24L41-R50): Modified the Flutter test command to include coverage (`flutter test --coverage`). Added steps to generate the coverage report using `genhtml` and upload the coverage report as an artifact using `actions/upload-artifact@v4`.