### PR TITLE
Update message container

### DIFF
--- a/ui/lib/components/messages/message_container.dart
+++ b/ui/lib/components/messages/message_container.dart
@@ -1,5 +1,6 @@
 // Flutter imports:
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class MessageContainer extends StatelessWidget {
   final String message;
@@ -14,24 +15,32 @@ class MessageContainer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final maxWidth = MediaQuery.of(context).size.width * 0.75;
-    return Align(
-      alignment: isUserMessage ? Alignment.centerRight : Alignment.centerLeft,
-      child: Container(
-        constraints: BoxConstraints(maxWidth: maxWidth),
-        margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
-        padding: const EdgeInsets.all(10),
-        decoration: BoxDecoration(
-          color: isUserMessage
-              ? Theme.of(context).colorScheme.primary
-              : Theme.of(context).colorScheme.secondary,
-          borderRadius: BorderRadius.circular(10),
-        ),
-        child: Text(
-          message,
-          style: TextStyle(
+    return GestureDetector(
+      onLongPress: () {
+        Clipboard.setData(ClipboardData(text: message));
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Copied to clipboard')),
+        );
+      },
+      child: Align(
+        alignment: isUserMessage ? Alignment.centerRight : Alignment.centerLeft,
+        child: Container(
+          constraints: BoxConstraints(maxWidth: maxWidth),
+          margin: const EdgeInsets.all(5),
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
             color: isUserMessage
-                ? Theme.of(context).colorScheme.onPrimary
-                : Theme.of(context).colorScheme.onSecondary,
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.secondary,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Text(
+            message,
+            style: TextStyle(
+              color: isUserMessage
+                  ? Theme.of(context).colorScheme.onPrimary
+                  : Theme.of(context).colorScheme.onSecondary,
+            ),
           ),
         ),
       ),

--- a/ui/lib/components/messages/message_container.dart
+++ b/ui/lib/components/messages/message_container.dart
@@ -14,36 +14,58 @@ class MessageContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final maxWidth = MediaQuery.of(context).size.width * 0.75;
+    final boxColour = isUserMessage
+        ? Theme.of(context).colorScheme.primary
+        : Theme.of(context).colorScheme.secondary;
+    final textColour = isUserMessage
+        ? Theme.of(context).colorScheme.onPrimary
+        : Theme.of(context).colorScheme.onSecondary;
+
+    void copyToClipboard() {
+      Clipboard.setData(ClipboardData(text: message));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Copied to clipboard')),
+      );
+    }
+
     return GestureDetector(
-      onLongPress: () {
-        Clipboard.setData(ClipboardData(text: message));
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Copied to clipboard')),
-        );
-      },
+      onLongPress: copyToClipboard,
       child: Align(
         alignment: isUserMessage ? Alignment.centerRight : Alignment.centerLeft,
-        child: Container(
-          constraints: BoxConstraints(maxWidth: maxWidth),
-          margin: const EdgeInsets.all(5),
-          padding: const EdgeInsets.all(10),
-          decoration: BoxDecoration(
-            color: isUserMessage
-                ? Theme.of(context).colorScheme.primary
-                : Theme.of(context).colorScheme.secondary,
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: Text(
-            message,
-            style: TextStyle(
-              color: isUserMessage
-                  ? Theme.of(context).colorScheme.onPrimary
-                  : Theme.of(context).colorScheme.onSecondary,
-            ),
-          ),
+        child: MessageBox(
+          message: message,
+          boxColour: boxColour,
+          textColour: textColour,
         ),
       ),
+    );
+  }
+}
+
+class MessageBox extends StatelessWidget {
+  final String message;
+  final Color boxColour;
+  final Color textColour;
+
+  const MessageBox({
+    Key? key,
+    required this.message,
+    required this.boxColour,
+    required this.textColour,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final maxWidth = MediaQuery.of(context).size.width * 0.75;
+    return Container(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 2),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: boxColour,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(message, style: TextStyle(color: textColour)),
     );
   }
 }

--- a/ui/lib/components/messages/message_container.dart
+++ b/ui/lib/components/messages/message_container.dart
@@ -5,11 +5,13 @@ import 'package:flutter/services.dart';
 class MessageContainer extends StatelessWidget {
   final String message;
   final bool isUserMessage;
+  final DateTime timestamp;
 
   const MessageContainer({
     Key? key,
     required this.message,
     required this.isUserMessage,
+    required this.timestamp,
   }) : super(key: key);
 
   @override
@@ -32,10 +34,17 @@ class MessageContainer extends StatelessWidget {
       onLongPress: copyToClipboard,
       child: Align(
         alignment: isUserMessage ? Alignment.centerRight : Alignment.centerLeft,
-        child: MessageBox(
-          message: message,
-          boxColour: boxColour,
-          textColour: textColour,
+        child: Column(
+          crossAxisAlignment:
+              isUserMessage ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+          children: [
+            MessageBox(
+              message: message,
+              boxColour: boxColour,
+              textColour: textColour,
+            ),
+            MessageTimestamp(timestamp: timestamp),
+          ],
         ),
       ),
     );
@@ -59,7 +68,7 @@ class MessageBox extends StatelessWidget {
     final maxWidth = MediaQuery.of(context).size.width * 0.75;
     return Container(
       constraints: BoxConstraints(maxWidth: maxWidth),
-      margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 2),
+      margin: const EdgeInsets.symmetric(vertical: 5),
       padding: const EdgeInsets.all(10),
       decoration: BoxDecoration(
         color: boxColour,
@@ -67,5 +76,27 @@ class MessageBox extends StatelessWidget {
       ),
       child: Text(message, style: TextStyle(color: textColour)),
     );
+  }
+}
+
+class MessageTimestamp extends StatelessWidget {
+  final DateTime timestamp;
+
+  const MessageTimestamp({
+    Key? key,
+    required this.timestamp,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final String dateText =
+        '${timestamp.day.toString().padLeft(2, '0')}/${timestamp.month.toString().padLeft(2, '0')}/${timestamp.year.toString().substring(2)}';
+    final String timeText =
+        '${timestamp.hour.toString().padLeft(2, '0')}:${timestamp.minute.toString().padLeft(2, '0')}';
+    final String text = '$dateText | $timeText';
+    final Color textColour = Theme.of(context).colorScheme.onBackground;
+    final TextStyle textStyle =
+        TextStyle(color: textColour.withOpacity(0.6), fontSize: 12);
+    return Text(text, style: textStyle);
   }
 }

--- a/ui/lib/components/messages/message_input.dart
+++ b/ui/lib/components/messages/message_input.dart
@@ -34,7 +34,11 @@ class _MessageInputState extends State<MessageInput> {
     if (userMessage.isEmpty) {
       return;
     }
-    messageState.addMessage({'text': userMessage, 'isUserMessage': true});
+    messageState.addMessage({
+      'text': userMessage,
+      'isUserMessage': true,
+      'timestamp': DateTime.now()
+    });
     textController.clear();
 
     Map<String, dynamic> message = await widget.httpHelper

--- a/ui/lib/components/messages/message_list.dart
+++ b/ui/lib/components/messages/message_list.dart
@@ -38,6 +38,7 @@ class _MessageListState extends State<MessageList> {
         return MessageContainer(
           message: message['text'],
           isUserMessage: message['isUserMessage'],
+          timestamp: DateTime.parse(message['timestamp'].toString()),
         );
       },
     );

--- a/ui/lib/helpers/http_helper.dart
+++ b/ui/lib/helpers/http_helper.dart
@@ -44,7 +44,8 @@ class HttpHelper {
       final Map<String, dynamic> body = jsonDecode(response.body);
       return {
         'text': body['message'].toString().trim(),
-        'isUserMessage': body['is_user_message']
+        'isUserMessage': body['is_user_message'],
+        'timestamp': DateTime.now(),
       };
     }
 
@@ -73,7 +74,8 @@ class HttpHelper {
         final Map<String, dynamic> body = jsonDecode(response.body);
         return {
           'text': body['message'].toString().trim(),
-          'isUserMessage': body['is_user_message']
+          'isUserMessage': body['is_user_message'],
+          'timestamp': DateTime.now(),
         };
       }
 

--- a/ui/lib/pages/home_page.dart
+++ b/ui/lib/pages/home_page.dart
@@ -48,6 +48,9 @@ class _HomePageState extends State<HomePage> {
         Provider.of<NotificationState>(context, listen: false);
 
     httpHelper.checkApiConnection('${appState.fullUrl}/').then((alive) {
+      if (appState.activePage == 'login') {
+        return;
+      }
       if (!appState.connected && alive) {
         appState.setConnected(alive);
         notificationState.setNotificationInfo('API connection restored!');

--- a/ui/test/components/messages/message_container_test.dart
+++ b/ui/test/components/messages/message_container_test.dart
@@ -27,6 +27,10 @@ void main() {
     final container = tester.widget<Container>(find.byType(Container));
     final decoration = container.decoration as BoxDecoration;
     expect(decoration.color, ThemeData().colorScheme.primary);
+
+    await tester.longPress(find.text('Hello, this is a user message'));
+    await tester.pumpAndSettle();
+    expect(find.text('Copied to clipboard'), findsOneWidget);
   });
 
   testWidgets('MessageContainer displays non-user message correctly',
@@ -48,5 +52,10 @@ void main() {
     final container = tester.widget<Container>(find.byType(Container));
     final decoration = container.decoration as BoxDecoration;
     expect(decoration.color, ThemeData().colorScheme.secondary);
+
+    // Long press to copy text
+    await tester.longPress(find.text('Hello, this is a non-user message'));
+    await tester.pumpAndSettle();
+    expect(find.text('Copied to clipboard'), findsOneWidget);
   });
 }

--- a/ui/test/components/messages/message_container_test.dart
+++ b/ui/test/components/messages/message_container_test.dart
@@ -10,19 +10,23 @@ import 'package:ui/components/messages/message_container.dart';
 void main() {
   testWidgets('MessageContainer displays user message correctly',
       (WidgetTester tester) async {
+    final timestamp = DateTime(2023, 10, 1, 14, 30);
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Scaffold(
           body: MessageContainer(
             message: 'Hello, this is a user message',
             isUserMessage: true,
+            timestamp: timestamp,
           ),
         ),
       ),
     );
 
     final messageFinder = find.text('Hello, this is a user message');
+    final timestampFinder = find.text('01/10/23 | 14:30');
     expect(messageFinder, findsOneWidget);
+    expect(timestampFinder, findsOneWidget);
 
     await tester.longPress(find.text('Hello, this is a user message'));
     await tester.pumpAndSettle();
@@ -31,19 +35,23 @@ void main() {
 
   testWidgets('MessageContainer displays non-user message correctly',
       (WidgetTester tester) async {
+    final timestamp = DateTime(2023, 10, 1, 14, 30);
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Scaffold(
           body: MessageContainer(
             message: 'Hello, this is a non-user message',
             isUserMessage: false,
+            timestamp: timestamp,
           ),
         ),
       ),
     );
 
     final messageFinder = find.text('Hello, this is a non-user message');
+    final timestampFinder = find.text('01/10/23 | 14:30');
     expect(messageFinder, findsOneWidget);
+    expect(timestampFinder, findsOneWidget);
 
     await tester.longPress(find.text('Hello, this is a non-user message'));
     await tester.pumpAndSettle();

--- a/ui/test/components/messages/message_container_test.dart
+++ b/ui/test/components/messages/message_container_test.dart
@@ -24,10 +24,6 @@ void main() {
     final messageFinder = find.text('Hello, this is a user message');
     expect(messageFinder, findsOneWidget);
 
-    final container = tester.widget<Container>(find.byType(Container));
-    final decoration = container.decoration as BoxDecoration;
-    expect(decoration.color, ThemeData().colorScheme.primary);
-
     await tester.longPress(find.text('Hello, this is a user message'));
     await tester.pumpAndSettle();
     expect(find.text('Copied to clipboard'), findsOneWidget);
@@ -49,13 +45,37 @@ void main() {
     final messageFinder = find.text('Hello, this is a non-user message');
     expect(messageFinder, findsOneWidget);
 
-    final container = tester.widget<Container>(find.byType(Container));
-    final decoration = container.decoration as BoxDecoration;
-    expect(decoration.color, ThemeData().colorScheme.secondary);
-
-    // Long press to copy text
     await tester.longPress(find.text('Hello, this is a non-user message'));
     await tester.pumpAndSettle();
     expect(find.text('Copied to clipboard'), findsOneWidget);
+  });
+
+  testWidgets('MessageBox displays message with correct colors',
+      (WidgetTester tester) async {
+    const message = 'Test message';
+    const boxColour = Colors.blue;
+    const textColour = Colors.white;
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: MessageBox(
+            message: message,
+            boxColour: boxColour,
+            textColour: textColour,
+          ),
+        ),
+      ),
+    );
+
+    final messageFinder = find.text(message);
+    expect(messageFinder, findsOneWidget);
+
+    final container = tester.widget<Container>(find.byType(Container));
+    final decoration = container.decoration as BoxDecoration;
+    expect(decoration.color, boxColour);
+
+    final text = tester.widget<Text>(find.text(message));
+    expect(text.style?.color, textColour);
   });
 }

--- a/ui/test/components/messages/message_list_test.dart
+++ b/ui/test/components/messages/message_list_test.dart
@@ -10,9 +10,18 @@ import 'package:ui/components/messages/message_list.dart';
 void main() {
   testWidgets('MessageList displays messages correctly',
       (WidgetTester tester) async {
+    final timestamp = DateTime(2023, 10, 1, 14, 30);
     final messages = [
-      {'text': 'Hello, this is a user message', 'isUserMessage': true},
-      {'text': 'Hello, this is a non-user message', 'isUserMessage': false},
+      {
+        'text': 'Hello, this is a user message',
+        'isUserMessage': true,
+        'timestamp': timestamp,
+      },
+      {
+        'text': 'Hello, this is a non-user message',
+        'isUserMessage': false,
+        'timestamp': timestamp,
+      },
     ];
 
     await tester.pumpWidget(
@@ -28,14 +37,21 @@ void main() {
 
     final userMessageFinder = find.text('Hello, this is a user message');
     final nonUserMessageFinder = find.text('Hello, this is a non-user message');
+    final timestampFinder = find.text('01/10/23 | 14:30');
 
     expect(userMessageFinder, findsOneWidget);
     expect(nonUserMessageFinder, findsOneWidget);
+    expect(timestampFinder, findsNWidgets(2));
   });
 
   testWidgets('MessageList scrolls to the bottom', (WidgetTester tester) async {
-    final messages = List.generate(20,
-        (index) => {'text': 'Message $index', 'isUserMessage': index % 2 == 0});
+    final messages = List.generate(
+        20,
+        (index) => {
+              'text': 'Message $index',
+              'isUserMessage': index % 2 == 0,
+              'timestamp': DateTime.now(),
+            });
     final scrollController = ScrollController();
 
     await tester.pumpWidget(

--- a/ui/test/components/timeout_dialog_test.dart
+++ b/ui/test/components/timeout_dialog_test.dart
@@ -1,5 +1,10 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
+
+// Package imports:
 import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
 import 'package:ui/components/timeout_dialog.dart';
 
 void main() {

--- a/ui/test/helpers/http_helper_test.dart
+++ b/ui/test/helpers/http_helper_test.dart
@@ -37,8 +37,11 @@ void main() {
       )).thenAnswer((_) async => http.Response(
           jsonEncode({'message': 'Welcome', 'is_user_message': true}), 200));
 
-      expect(await httpHelper.getLoginResponse(uri, authToken),
-          {'text': 'Welcome', 'isUserMessage': true});
+      expect(await httpHelper.getLoginResponse(uri, authToken), {
+        'text': 'Welcome',
+        'isUserMessage': true,
+        'timestamp': isA<DateTime>(),
+      });
     });
 
     test(
@@ -79,8 +82,11 @@ void main() {
       )).thenAnswer((_) async => http.Response(
           jsonEncode({'message': 'Hi', 'is_user_message': false}), 200));
 
-      expect(await httpHelper.chat(uri, authToken, message),
-          {'text': 'Hi', 'isUserMessage': false});
+      expect(await httpHelper.chat(uri, authToken, message), {
+        'text': 'Hi',
+        'isUserMessage': false,
+        'timestamp': isA<DateTime>(),
+      });
     });
 
     test('chat returns empty dict if the http call completes with an error',


### PR DESCRIPTION
This pull request introduces several enhancements to the messaging components, including the addition of timestamps to messages, the ability to copy messages to the clipboard, and updates to the test cases to reflect these changes. The most important changes are summarized below:

### Enhancements to Message Components:

* [`ui/lib/components/messages/message_container.dart`](diffhunk://#diff-29fb457b1a8ce362e0248b3b29cdb0e8141d6128dc3c886f9f9ae93767718becR3-R102): Added `timestamp` property to `MessageContainer` and created new `MessageBox` and `MessageTimestamp` components. Implemented functionality to copy messages to the clipboard on long press.
* [`ui/lib/components/messages/message_input.dart`](diffhunk://#diff-43ac33dd197b73c77d34de76a534d1af4c3a2237c73ddb71b884c2f074df9fadL37-R41): Updated `addMessage` method to include `timestamp` when adding a new message.
* [`ui/lib/components/messages/message_list.dart`](diffhunk://#diff-c7ead6b1f726e13249a9b4b99abd536cb2ca30d26134958dbff57004aab4a93aR41): Updated `MessageContainer` instantiation to pass the `timestamp` property.

### Updates to HTTP Helper:

* [`ui/lib/helpers/http_helper.dart`](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50L47-R48): Added `timestamp` property to the response of `getLoginResponse` and `chat` methods. [[1]](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50L47-R48) [[2]](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50L76-R78)

### Test Case Updates:

* [`ui/test/components/messages/message_container_test.dart`](diffhunk://#diff-2acb2e1d487388d36aa40c610d87db189ab3d8f8c218f082fff49a58ad7f191aR13-R87): Updated tests to verify the display of timestamps and the copy-to-clipboard functionality. Added new test for `MessageBox` color properties.
* [`ui/test/components/messages/message_list_test.dart`](diffhunk://#diff-94e476c0fafe5bb50533126ea5322a02559b21204ecf7d5f96d49d8dbf39ef46R13-R24): Updated tests to include `timestamp` in messages and verify their correct display. [[1]](diffhunk://#diff-94e476c0fafe5bb50533126ea5322a02559b21204ecf7d5f96d49d8dbf39ef46R13-R24) [[2]](diffhunk://#diff-94e476c0fafe5bb50533126ea5322a02559b21204ecf7d5f96d49d8dbf39ef46R40-R54)
* [`ui/test/helpers/http_helper_test.dart`](diffhunk://#diff-366ca53d051a6c3bd64affe277df189f3ddeae51623a93d5459b138a516c32c9L40-R44): Updated tests to check for the presence of `timestamp` in the responses. [[1]](diffhunk://#diff-366ca53d051a6c3bd64affe277df189f3ddeae51623a93d5459b138a516c32c9L40-R44) [[2]](diffhunk://#diff-366ca53d051a6c3bd64affe277df189f3ddeae51623a93d5459b138a516c32c9L82-R89)