### PR TITLE
Update ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
+    "A",
     "ANN",
     "ASYNC",
     "B",
@@ -98,15 +99,17 @@ select = [
     "NPY",
     "PD",
     "PERF",
+    "PL",
     "PT",
     "RET",
     "RUF",
+    "S",
     "TRY",
     "UP",
     "W",
     "YTT",
 ]
-ignore = ["G004"]
+ignore = ["E501","E741","ISC001","N999"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,16 @@ select = [
     "W",
     "YTT",
 ]
-ignore = ["E501","E741","ISC001","N999"]
+ignore = [
+  "E501",
+  "E741",
+  "G004",
+  "ISC001",
+  "N999",
+  "S101",
+  "S104",
+  "S105"
+]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/src/rpi_ai/main.py
+++ b/src/rpi_ai/main.py
@@ -87,13 +87,13 @@ class AIApp:
         logger.info(response)
         return jsonify(response)
 
-    def run(self, host: str, port: int) -> None:
-        def shutdown_handler(signum: int, frame: FrameType) -> None:
-            logger.info("Shutting down AI...")
-            self.app.do_teardown_appcontext()
-            os._exit(0)
+    def shutdown_handler(self, signum: int, frame: FrameType) -> None:
+        logger.info("Shutting down AI...")
+        self.app.do_teardown_appcontext()
+        os._exit(0)
 
-        signal.signal(signal.SIGINT, shutdown_handler)
+    def run(self, host: str, port: int) -> None:
+        signal.signal(signal.SIGINT, self.shutdown_handler)
         self.app.run(host=host, port=port)
 
 

--- a/tests/rpi_ai/conftest.py
+++ b/tests/rpi_ai/conftest.py
@@ -12,7 +12,12 @@ from rpi_ai.models.chatbot import Chatbot
 # Config fixtures
 @pytest.fixture
 def config_data() -> dict[str, str | float]:
-    return {"model": "test-model", "candidate_count": 2, "max_output_tokens": 50, "temperature": 0.7}
+    return {
+        "model": "test-model",
+        "candidate_count": 2,
+        "max_output_tokens": 50,
+        "temperature": 0.7,
+    }
 
 
 @pytest.fixture
@@ -43,7 +48,9 @@ def mock_start_chat_method(mock_generative_model: MagicMock) -> MagicMock:
 @pytest.fixture
 def mock_chat_instance(mock_start_chat_method: MagicMock) -> MagicMock:
     mock_chat_instance = MagicMock()
-    mock_chat_instance.history = [MagicMock(role="model", parts="What's on your mind today")]
+    mock_chat_instance.history = [
+        MagicMock(role="model", parts="What's on your mind today")
+    ]
     mock_start_chat_method.return_value = mock_chat_instance
     return mock_chat_instance
 
@@ -51,7 +58,9 @@ def mock_chat_instance(mock_start_chat_method: MagicMock) -> MagicMock:
 @pytest.fixture
 def mock_generate_content(mock_generative_model: MagicMock) -> MagicMock:
     mock_chat_instance = MagicMock()
-    mock_generative_model.return_value.generate_content.return_value = mock_chat_instance
+    mock_generative_model.return_value.generate_content.return_value = (
+        mock_chat_instance
+    )
     return mock_generative_model.return_value.generate_content
 
 

--- a/tests/rpi_ai/models/test_types.py
+++ b/tests/rpi_ai/models/test_types.py
@@ -27,7 +27,7 @@ class TestMessageList:
         ]
         mock_extract_parts.side_effect = [data[0]["parts"], data[1]["parts"]]
         message_list = MessageList.from_history(data)
-        assert len(message_list.messages) == 2
+        assert len(message_list.messages) == len(data)
         assert message_list.messages[0].message == "Hello, world!"
         assert message_list.messages[0].is_user_message
         assert message_list.messages[1].message == "Hello, user!"

--- a/tests/rpi_ai/test_config.py
+++ b/tests/rpi_ai/test_config.py
@@ -9,13 +9,13 @@ class TestAIConfigType:
         with patch("builtins.open", new_callable=mock_open, read_data=json.dumps(config_data)):
             config = AIConfigType.load("dummy_path")
             assert config.model == "test-model"
-            assert config.candidate_count == 2
-            assert config.max_output_tokens == 50
-            assert config.temperature == 0.7
+            assert config.candidate_count == config_data["candidate_count"]
+            assert config.max_output_tokens == config_data["max_output_tokens"]
+            assert config.temperature == config_data["temperature"]
 
     def test_generation_config(self, config_data: dict[str, str | float]) -> None:
         config = AIConfigType(**config_data)
         gen_config = config.generation_config
-        assert gen_config.candidate_count == 2
-        assert gen_config.max_output_tokens == 50
-        assert gen_config.temperature == 0.7
+        assert gen_config.candidate_count == config_data["candidate_count"]
+        assert gen_config.max_output_tokens == config_data["max_output_tokens"]
+        assert gen_config.temperature == config_data["temperature"]

--- a/tests/rpi_ai/test_main.py
+++ b/tests/rpi_ai/test_main.py
@@ -4,6 +4,9 @@ from flask.testing import FlaskClient
 
 from rpi_ai.main import AIApp
 
+SUCCESS_CODE = 200
+UNAUTHORIZED_CODE = 401
+
 
 class TestAIApp:
     def test_authenticate_success(self, mock_ai_app: AIApp, mock_request_headers: MagicMock) -> None:
@@ -17,11 +20,10 @@ class TestAIApp:
     def test_is_alive(self, mock_client: FlaskClient, mock_jsonify: MagicMock) -> None:
         response = mock_client.get("/")
         mock_jsonify.assert_called_once_with({"status": "alive"})
-        assert response.status_code == 200
+        assert response.status_code == SUCCESS_CODE
 
     def test_login(
         self,
-        mock_ai_app: AIApp,
         mock_client: FlaskClient,
         mock_request_headers: MagicMock,
         mock_start_chat: MagicMock,
@@ -31,7 +33,7 @@ class TestAIApp:
         response = mock_client.get("/login")
         mock_start_chat.assert_called_once()
         mock_jsonify.assert_called_once_with(mock_start_chat.return_value)
-        assert response.status_code == 200
+        assert response.status_code == SUCCESS_CODE
 
     def test_login_unauthorized(
         self,
@@ -42,11 +44,10 @@ class TestAIApp:
         mock_request_headers.return_value = {"Authorization": "wrong_token"}
         response = mock_client.get("/login")
         mock_jsonify.assert_called_once_with({"error": "Unauthorized"})
-        assert response.status_code == 401
+        assert response.status_code == UNAUTHORIZED_CODE
 
     def test_chat(
         self,
-        mock_ai_app: AIApp,
         mock_client: FlaskClient,
         mock_request_headers: MagicMock,
         mock_request_json: MagicMock,
@@ -60,7 +61,7 @@ class TestAIApp:
         response = mock_client.post("/chat")
         mock_send_message.assert_called_once_with(user_message)
         mock_jsonify.assert_called_once_with(mock_send_message.return_value)
-        assert response.status_code == 200
+        assert response.status_code == SUCCESS_CODE
 
     def test_chat_unauthorized(
         self,
@@ -75,11 +76,10 @@ class TestAIApp:
 
         response = mock_client.post("/chat")
         mock_jsonify.assert_called_once_with({"error": "Unauthorized"})
-        assert response.status_code == 401
+        assert response.status_code == UNAUTHORIZED_CODE
 
     def test_command(
         self,
-        mock_ai_app: AIApp,
         mock_client: FlaskClient,
         mock_request_headers: MagicMock,
         mock_request_json: MagicMock,
@@ -93,7 +93,7 @@ class TestAIApp:
         response = mock_client.post("/command")
         mock_send_command.assert_called_once_with(user_message)
         mock_jsonify.assert_called_once_with(mock_send_command.return_value)
-        assert response.status_code == 200
+        assert response.status_code == SUCCESS_CODE
 
     def test_command_unauthorized(
         self,
@@ -108,4 +108,4 @@ class TestAIApp:
 
         response = mock_client.post("/command")
         mock_jsonify.assert_called_once_with({"error": "Unauthorized"})
-        assert response.status_code == 401
+        assert response.status_code == UNAUTHORIZED_CODE


### PR DESCRIPTION
This pull request includes changes to the `pyproject.toml` file to update the linting configuration. The most important changes include adding new linting categories to the `select` list and updating the `ignore` list with additional error codes.

Linting configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R85): Added new linting categories "A", "PL", and "S" to the `select` list. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R85) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R102-R112)
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R102-R112): Updated the `ignore` list to include error codes "E501", "E741", "ISC001", and "N999".