### PR TITLE
Extract appbar widget

### DIFF
--- a/ui/lib/components/app_bar/custom_app_bar.dart
+++ b/ui/lib/components/app_bar/custom_app_bar.dart
@@ -1,0 +1,32 @@
+// Flutter imports:
+import 'package:flutter/material.dart';
+
+// Project imports:
+import 'package:ui/components/app_bar/logout_button.dart';
+import 'package:ui/components/app_bar/switch_chat_mode.dart';
+import 'package:ui/state/app_state.dart';
+import 'package:ui/types.dart';
+
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final AppState appState;
+
+  const CustomAppBar({Key? key, required this.appState}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      title: Text(appState.activePage.title),
+      leading:
+          appState.activePage != PageType.login ? const SwitchChatMode() : null,
+      actions: appState.activePage != PageType.login
+          ? [
+              const LogoutButton(),
+            ]
+          : null,
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/ui/lib/pages/home_page.dart
+++ b/ui/lib/pages/home_page.dart
@@ -9,8 +9,7 @@ import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 
 // Project imports:
-import 'package:ui/components/app_bar/logout_button.dart';
-import 'package:ui/components/app_bar/switch_chat_mode.dart';
+import 'package:ui/components/app_bar/custom_app_bar.dart';
 import 'package:ui/components/notifications.dart';
 import 'package:ui/components/timeout_dialog.dart';
 import 'package:ui/helpers/http_helper.dart';
@@ -121,18 +120,7 @@ class _HomePageState extends State<HomePage> {
     }
 
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(appState.appBarTitle),
-        leading: appState.activePage != PageType.login
-            ? const SwitchChatMode()
-            : null,
-        actions: appState.activePage != PageType.login
-            ? [
-                const LogoutButton(),
-              ]
-            : null,
-      ),
+      appBar: CustomAppBar(appState: appState),
       body: Stack(
         children: [
           Center(

--- a/ui/lib/state/app_state.dart
+++ b/ui/lib/state/app_state.dart
@@ -9,7 +9,6 @@ class AppState extends ChangeNotifier {
   int _port = 5000;
   String _authToken = '';
   PageType _activePage = PageType.login;
-  String _appBarTitle = PageType.login.title;
   bool _connected = false;
 
   String get ip => _ip;
@@ -17,7 +16,6 @@ class AppState extends ChangeNotifier {
   String get fullUrl => 'http://$_ip:$_port';
   String get authToken => _authToken;
   PageType get activePage => _activePage;
-  String get appBarTitle => _appBarTitle;
   bool get connected => _connected;
 
   void setIp(String newIp) {
@@ -37,12 +35,6 @@ class AppState extends ChangeNotifier {
 
   void setActivePage(PageType newPage) {
     _activePage = newPage;
-    _appBarTitle = newPage.title;
-    notifyListeners();
-  }
-
-  void setConnected(bool newConnected) {
-    _connected = newConnected;
     notifyListeners();
   }
 
@@ -52,6 +44,11 @@ class AppState extends ChangeNotifier {
     } else if (_activePage == PageType.command) {
       setActivePage(PageType.chat);
     }
+    notifyListeners();
+  }
+
+  void setConnected(bool newConnected) {
+    _connected = newConnected;
     notifyListeners();
   }
 }

--- a/ui/test/components/app_bar/custom_app_bar_test.dart
+++ b/ui/test/components/app_bar/custom_app_bar_test.dart
@@ -1,0 +1,82 @@
+// Flutter imports:
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+// Project imports:
+import 'package:ui/components/app_bar/custom_app_bar.dart';
+import 'package:ui/components/app_bar/logout_button.dart';
+import 'package:ui/components/app_bar/switch_chat_mode.dart';
+import 'package:ui/state/app_state.dart';
+import 'package:ui/types.dart';
+
+void main() {
+  Widget createCustomAppBar(AppState appState) {
+    return ChangeNotifierProvider(
+      create: (context) => appState,
+      child: MaterialApp(
+        home: Scaffold(
+          appBar: CustomAppBar(appState: appState),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('CustomAppBar displays title for login page',
+      (WidgetTester tester) async {
+    final appState = AppState();
+    appState.setActivePage(PageType.login);
+    await tester.pumpWidget(createCustomAppBar(appState));
+    expect(find.text(PageType.login.title), findsOneWidget);
+  });
+
+  testWidgets('CustomAppBar displays title for chat page',
+      (WidgetTester tester) async {
+    final appState = AppState();
+    appState.setActivePage(PageType.chat);
+    await tester.pumpWidget(createCustomAppBar(appState));
+    expect(find.text(PageType.chat.title), findsOneWidget);
+  });
+
+  testWidgets('CustomAppBar displays title for command page',
+      (WidgetTester tester) async {
+    final appState = AppState();
+    appState.setActivePage(PageType.command);
+    await tester.pumpWidget(createCustomAppBar(appState));
+    expect(find.text(PageType.command.title), findsOneWidget);
+  });
+
+  testWidgets('CustomAppBar displays SwitchChatMode',
+      (WidgetTester tester) async {
+    final appState = AppState();
+    appState.setActivePage(PageType.chat);
+    await tester.pumpWidget(createCustomAppBar(appState));
+    expect(find.byType(SwitchChatMode), findsOneWidget);
+  });
+
+  testWidgets('CustomAppBar does not display SwitchChatMode on login page',
+      (WidgetTester tester) async {
+    final appState = AppState();
+    appState.setActivePage(PageType.login);
+    await tester.pumpWidget(createCustomAppBar(appState));
+    expect(find.byType(SwitchChatMode), findsNothing);
+  });
+
+  testWidgets('CustomAppBar displays LogoutButton',
+      (WidgetTester tester) async {
+    final appState = AppState();
+    appState.setActivePage(PageType.chat);
+    await tester.pumpWidget(createCustomAppBar(appState));
+    expect(find.byType(LogoutButton), findsOneWidget);
+  });
+
+  testWidgets('CustomAppBar does not display LogoutButton on login page',
+      (WidgetTester tester) async {
+    final appState = AppState();
+    appState.setActivePage(PageType.login);
+    await tester.pumpWidget(createCustomAppBar(appState));
+    expect(find.byType(LogoutButton), findsNothing);
+  });
+}

--- a/ui/test/pages/home_page_test.dart
+++ b/ui/test/pages/home_page_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
 // Project imports:
+import 'package:ui/components/app_bar/custom_app_bar.dart';
 import 'package:ui/components/app_bar/logout_button.dart';
 import 'package:ui/components/app_bar/switch_chat_mode.dart';
 import 'package:ui/components/timeout_dialog.dart';
@@ -29,14 +30,9 @@ void main() {
     );
   }
 
-  testWidgets('HomePage displays AppBar', (WidgetTester tester) async {
+  testWidgets('HomePage displays CustomAppBar', (WidgetTester tester) async {
     await tester.pumpWidget(createHomePage(AppState()));
-    expect(find.byType(AppBar), findsOneWidget);
-  });
-
-  testWidgets('HomePage displays title', (WidgetTester tester) async {
-    await tester.pumpWidget(createHomePage(AppState()));
-    expect(find.text('Login'), findsOneWidget);
+    expect(find.byType(CustomAppBar), findsOneWidget);
   });
 
   testWidgets('HomePage displays SwitchChatMode', (WidgetTester tester) async {


### PR DESCRIPTION
This pull request focuses on refactoring the app bar component and updating the related state management and tests in the Flutter project. The main changes include the creation of a custom app bar widget, the removal of redundant state properties, and the addition of new tests to ensure the functionality of the custom app bar.

Refactoring and state management updates:

* Created a new `CustomAppBar` widget in `ui/lib/components/app_bar/custom_app_bar.dart` to encapsulate the app bar logic, including the display of the title, `SwitchChatMode`, and `LogoutButton` based on the active page.
* Updated `HomePage` to use the new `CustomAppBar` widget instead of directly defining the app bar within the scaffold. [[1]](diffhunk://#diff-273351b62a97cc55103c12523afb9ed06b2ec32bfba8e6e8f7ba52a0d16c8db6L12-R12) [[2]](diffhunk://#diff-273351b62a97cc55103c12523afb9ed06b2ec32bfba8e6e8f7ba52a0d16c8db6L124-R123)
* Removed the `appBarTitle` property from `AppState` and updated the `setActivePage` method to no longer set this property. [[1]](diffhunk://#diff-92e613c936b01b5e4b7ceb7a812edd3816580f55b65c78754f3ece7cd22d5163L12-L20) [[2]](diffhunk://#diff-92e613c936b01b5e4b7ceb7a812edd3816580f55b65c78754f3ece7cd22d5163L40-L45)
* Moved the `setConnected` method in `AppState` to a more appropriate location.

Testing updates:

* Added new tests for the `CustomAppBar` widget in `ui/test/components/app_bar/custom_app_bar_test.dart` to verify the correct display of titles and buttons based on the active page.
* Updated existing tests in `ui/test/pages/home_page_test.dart` to check for the presence of `CustomAppBar` instead of the default `AppBar`. [[1]](diffhunk://#diff-d0520bafb0ad2a23c3c6977661b1d00de901949e9fbc1adf976fe51e2dcf9312R9) [[2]](diffhunk://#diff-d0520bafb0ad2a23c3c6977661b1d00de901949e9fbc1adf976fe51e2dcf9312L32-R35)