### PR TITLE
Add system instructions to AI configuration

### DIFF
--- a/config/ai_config.json
+++ b/config/ai_config.json
@@ -1,6 +1,7 @@
 {
     "model": "gemini-1.5-flash",
+    "system_instruction": "You are a friendly AI assistant. You are designed to help the user with daily tasks.",
     "candidate_count": 1,
-    "max_output_tokens": 100,
+    "max_output_tokens": 1000,
     "temperature": 1.0
 }

--- a/src/rpi_ai/config.py
+++ b/src/rpi_ai/config.py
@@ -9,6 +9,7 @@ from pydantic.dataclasses import dataclass
 @dataclass
 class AIConfigType:
     model: str
+    system_instruction: str
     candidate_count: int = 1
     max_output_tokens: int = 20
     temperature: float = 1.0

--- a/src/rpi_ai/models/chatbot.py
+++ b/src/rpi_ai/models/chatbot.py
@@ -12,16 +12,21 @@ from rpi_ai.models.types import CallableFunctionResponse, FunctionsList, Message
 class Chatbot:
     def __init__(self, api_key: str, config: AIConfigType, functions: FunctionsList) -> None:
         genai.configure(api_key=api_key)
-
         self._config = config
         self._functions = functions
-        self._model = genai.GenerativeModel(
-            self._config.model, generation_config=self._config.generation_config, tools=self._functions.functions
-        )
+        self._initialise_model()
 
     @property
     def first_message(self) -> dict[str, str]:
         return {"role": "model", "parts": "What's on your mind today?"}
+
+    def _initialise_model(self) -> None:
+        self._model = genai.GenerativeModel(
+            self._config.model,
+            system_instruction=self._config.system_instruction,
+            generation_config=self._config.generation_config,
+            tools=self._functions.functions,
+        )
 
     def _extract_command_from_part(self, part: Part) -> CallableFunctionResponse:
         try:

--- a/tests/rpi_ai/conftest.py
+++ b/tests/rpi_ai/conftest.py
@@ -16,6 +16,7 @@ from rpi_ai.models.types import FunctionsList
 def config_data() -> dict[str, str | float]:
     return {
         "model": "test-model",
+        "system_instruction": "test-instruction",
         "candidate_count": 2,
         "max_output_tokens": 50,
         "temperature": 0.7,

--- a/tests/rpi_ai/models/test_chatbot.py
+++ b/tests/rpi_ai/models/test_chatbot.py
@@ -18,7 +18,10 @@ class TestChatbot:
     ) -> None:
         mock_genai_configure.assert_called_once_with(api_key=mock_api_key.return_value)
         mock_generative_model.assert_called_once_with(
-            mock_config.model, generation_config=mock_config.generation_config, tools=mock_chatbot._functions.functions
+            mock_config.model,
+            system_instruction=mock_config.system_instruction,
+            generation_config=mock_config.generation_config,
+            tools=mock_chatbot._functions.functions,
         )
 
     def test_first_message(self, mock_chatbot: Chatbot) -> None:


### PR DESCRIPTION
This pull request includes several changes to enhance the configuration and initialization of the AI model. The most important changes include updating the AI configuration, modifying the `Chatbot` class to initialize the model with the new configuration, and updating the tests to reflect these changes.

### Configuration updates:
* [`config/ai_config.json`](diffhunk://#diff-01a6f87b93df504118506dc46c08eee8a74eb3ab8cf8881e2a3ed62fd110a2eeR3-R5): Added a new `system_instruction` field and increased the `max_output_tokens` limit from 100 to 1000.
* [`src/rpi_ai/config.py`](diffhunk://#diff-380df669070854875613184f9aa12861096a5df205b5501bc89a98d9aa4d40b8R12): Added the `system_instruction` field to the `AIConfigType` dataclass.

### Codebase updates:
* [`src/rpi_ai/models/chatbot.py`](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL15-R30): Refactored the `Chatbot` class to initialize the model using a new `_initialise_model` method, which includes the `system_instruction` field.

### Test updates:
* [`tests/rpi_ai/conftest.py`](diffhunk://#diff-3af729e32e4270155008c31b1a85406218bdf36d989cc683c325746b68ef6f13R19): Updated the `config_data` fixture to include the `system_instruction` field.
* [`tests/rpi_ai/models/test_chatbot.py`](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL21-R24): Modified the `test_init` function to check for the `system_instruction` field in the model initialization.