### PR TITLE
Add more system functions

### DIFF
--- a/src/rpi_ai/function_calling/system_info.py
+++ b/src/rpi_ai/function_calling/system_info.py
@@ -23,6 +23,8 @@ class SystemInfo(FunctionsListBase):
             SystemInfo.get_memory_usage,
             SystemInfo.get_disk_usage,
             SystemInfo.get_temperature,
+            SystemInfo.get_fan_speeds,
+            SystemInfo.get_battery_info,
         ]
 
     @staticmethod

--- a/src/rpi_ai/function_calling/system_info.py
+++ b/src/rpi_ai/function_calling/system_info.py
@@ -23,8 +23,6 @@ class SystemInfo(FunctionsListBase):
             SystemInfo.get_memory_usage,
             SystemInfo.get_disk_usage,
             SystemInfo.get_temperature,
-            SystemInfo.get_fan_speeds,
-            SystemInfo.get_battery_info,
         ]
 
     @staticmethod
@@ -158,42 +156,3 @@ class SystemInfo(FunctionsListBase):
             return SystemInfo._psutil_temperature()
         except (KeyError, IndexError, AttributeError):
             logger.exception("Failed to get CPU temperature.")
-
-    @staticmethod
-    def _psutil_fans() -> dict:
-        """
-        Get the fan speeds using `psutil`.
-
-        Returns:
-            dict: A dictionary containing fan labels and speeds.
-        """
-        return {f.label: f.current for f in psutil.sensors_fans().values()}
-
-    @staticmethod
-    def get_fan_speeds() -> dict:
-        """
-        Get the system fan speeds.
-
-        Returns:
-            dict: A dictionary containing fan labels and speeds.
-            `None` is returned if the fan speeds cannot be retrieved.
-        """
-        try:
-            return SystemInfo._psutil_fans()
-        except (KeyError, IndexError, AttributeError):
-            logger.exception("Failed to get fan speeds.")
-
-    @staticmethod
-    def get_battery_info() -> dict:
-        """
-        Get the battery information.
-
-        Returns:
-            dict: A dictionary containing battery information.
-        """
-        battery = psutil.sensors_battery()
-        return {
-            "percent": battery.percent,
-            "power_plugged": battery.power_plugged,
-            "secsleft": battery.secsleft,
-        }

--- a/src/rpi_ai/function_calling/system_info.py
+++ b/src/rpi_ai/function_calling/system_info.py
@@ -27,20 +27,18 @@ class SystemInfo(FunctionsListBase):
         ]
 
     @staticmethod
-    def os_info() -> str:
+    def os_info() -> dict:
         """
         Get the operating system information.
         """
-        return str(
-            {
-                "system": platform.system(),
-                "node": platform.node(),
-                "release": platform.release(),
-                "version": platform.version(),
-                "machine": platform.machine(),
-                "processor": platform.processor(),
-            }
-        )
+        return {
+            "system": platform.system(),
+            "node": platform.node(),
+            "release": platform.release(),
+            "version": platform.version(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+        }
 
     @staticmethod
     def hostname() -> str:
@@ -69,7 +67,7 @@ class SystemInfo(FunctionsListBase):
         """
         Get the running processes.
         """
-        return str({p.pid: p.info for p in psutil.process_iter(["pid", "name", "username"])})
+        return {p.pid: p.info for p in psutil.process_iter(["pid", "name", "username"])}
 
     @staticmethod
     def get_process_name_by_pid(pid: int) -> str:

--- a/src/rpi_ai/function_calling/system_info.py
+++ b/src/rpi_ai/function_calling/system_info.py
@@ -22,7 +22,7 @@ class SystemInfo(FunctionsListBase):
             SystemInfo.get_cpu_percent,
             SystemInfo.get_memory_usage,
             SystemInfo.get_disk_usage,
-            SystemInfo.temperature,
+            SystemInfo.get_temperature,
         ]
 
     @staticmethod
@@ -156,3 +156,42 @@ class SystemInfo(FunctionsListBase):
             return SystemInfo._psutil_temperature()
         except (KeyError, IndexError, AttributeError):
             logger.exception("Failed to get CPU temperature.")
+
+    @staticmethod
+    def _psutil_fans() -> dict:
+        """
+        Get the fan speeds using `psutil`.
+
+        Returns:
+            dict: A dictionary containing fan labels and speeds.
+        """
+        return {f.label: f.current for f in psutil.sensors_fans().values()}
+
+    @staticmethod
+    def get_fan_speeds() -> dict:
+        """
+        Get the system fan speeds.
+
+        Returns:
+            dict: A dictionary containing fan labels and speeds.
+            `None` is returned if the fan speeds cannot be retrieved.
+        """
+        try:
+            return SystemInfo._psutil_fans()
+        except (KeyError, IndexError, AttributeError):
+            logger.exception("Failed to get fan speeds.")
+
+    @staticmethod
+    def get_battery_info() -> dict:
+        """
+        Get the battery information.
+
+        Returns:
+            dict: A dictionary containing battery information.
+        """
+        battery = psutil.sensors_battery()
+        return {
+            "percent": battery.percent,
+            "power_plugged": battery.power_plugged,
+            "secsleft": battery.secsleft,
+        }

--- a/src/rpi_ai/function_calling/system_info.py
+++ b/src/rpi_ai/function_calling/system_info.py
@@ -14,22 +14,24 @@ class SystemInfo(FunctionsListBase):
     def __init__(self) -> None:
         super().__init__()
         self.functions = [
-            SystemInfo.os_info,
-            SystemInfo.hostname,
-            SystemInfo.ip_address,
-            SystemInfo.uptime,
+            SystemInfo.get_os_info,
+            SystemInfo.get_hostname,
+            SystemInfo.get_uptime,
             SystemInfo.get_running_processes,
             SystemInfo.get_process_name_by_pid,
-            SystemInfo.cpu_percent,
-            SystemInfo.memory_percent,
-            SystemInfo.disk_usage,
+            SystemInfo.get_cpu_percent,
+            SystemInfo.get_memory_usage,
+            SystemInfo.get_disk_usage,
             SystemInfo.temperature,
         ]
 
     @staticmethod
-    def os_info() -> dict:
+    def get_os_info() -> dict:
         """
         Get the operating system information.
+
+        Returns:
+            dict: A dictionary containing the OS information.
         """
         return {
             "system": platform.system(),
@@ -41,23 +43,22 @@ class SystemInfo(FunctionsListBase):
         }
 
     @staticmethod
-    def hostname() -> str:
+    def get_hostname() -> str:
         """
         Get the system hostname.
+
+        Returns:
+            str: The system hostname.
         """
         return socket.gethostname()
 
     @staticmethod
-    def ip_address() -> str:
-        """
-        Get the system IP address.
-        """
-        return socket.gethostbyname(SystemInfo.hostname())
-
-    @staticmethod
-    def uptime() -> str:
+    def get_uptime() -> str:
         """
         Get the system uptime.
+
+        Returns:
+            str: The system uptime as a string.
         """
         boot_time = datetime.fromtimestamp(psutil.boot_time())
         return str(datetime.now() - boot_time)
@@ -66,6 +67,9 @@ class SystemInfo(FunctionsListBase):
     def get_running_processes() -> dict:
         """
         Get the running processes.
+
+        Returns:
+            dict: A dictionary of running processes with PID as keys.
         """
         return {p.pid: p.info for p in psutil.process_iter(["pid", "name", "username"])}
 
@@ -73,6 +77,12 @@ class SystemInfo(FunctionsListBase):
     def get_process_name_by_pid(pid: int) -> str:
         """
         Get the name of a running process based on its PID.
+
+        Args:
+            pid (int): The process ID.
+
+        Returns:
+            str: The name of the process.
         """
         pid = int(pid)
         try:
@@ -82,38 +92,65 @@ class SystemInfo(FunctionsListBase):
             logger.exception(f"No process found with PID {pid}.")
 
     @staticmethod
-    def cpu_percent() -> float:
+    def get_cpu_percent() -> float:
         """
         Get the CPU usage percentage.
+
+        Returns:
+            float: The CPU usage percentage.
         """
         return psutil.cpu_percent(interval=1)
 
     @staticmethod
-    def memory_percent() -> float:
+    def get_memory_usage() -> dict:
         """
-        Get the memory usage percentage.
+        Get the memory usage.
+
+        Returns:
+            dict: A dictionary containing memory usage information.
         """
-        return psutil.virtual_memory().percent
+        virtual_memory = psutil.virtual_memory()
+        return {
+            "total": virtual_memory.total,
+            "available": virtual_memory.available,
+            "used": virtual_memory.used,
+            "percent": virtual_memory.percent,
+        }
 
     @staticmethod
-    def disk_usage() -> float:
+    def get_disk_usage() -> dict:
         """
-        Get the disk usage percentage.
+        Get the disk usage.
+
+        Returns:
+            dict: A dictionary containing disk usage information.
         """
-        return psutil.disk_usage("/").percent
+        disk_usage = psutil.disk_usage("/")
+        return {
+            "total": disk_usage.total,
+            "used": disk_usage.used,
+            "free": disk_usage.free,
+            "percent": disk_usage.percent,
+        }
 
     @staticmethod
     def _psutil_temperature() -> float:
         """
         Get the CPU temperature using `psutil`.
+
+        Returns:
+            float: The CPU temperature in degrees Celsius.
         """
-        return psutil.sensors_temperatures()["cpu-thermal"][0].current
+        return psutil.sensors_temperatures()["cpu_thermal"][0].current
 
     @staticmethod
-    def temperature() -> float:
+    def get_temperature() -> float:
         """
         Get the CPU temperature in degrees Celsius.
-        `None` is returned if the temperature cannot be retrieved.
+
+        Returns:
+            float: The CPU temperature in degrees Celsius.
+            `None` is returned if the temperature cannot be retrieved.
         """
         try:
             return SystemInfo._psutil_temperature()

--- a/src/rpi_ai/main.py
+++ b/src/rpi_ai/main.py
@@ -30,6 +30,8 @@ class AIApp:
             logger.error(msg)
             raise ValueError(msg)
 
+        logger.info(f"Generated token: {self.token}")
+
         self.chatbot = Chatbot(self.api_key, self.config, FUNCTIONS)
 
         self.app = Flask(__name__)
@@ -83,7 +85,6 @@ class AIApp:
         except AttributeError:
             self._token = self.create_new_token()
             self.write_token_to_file(self._token)
-            logger.info(f"Generated token: {self._token}")
             return self._token
 
     def get_request_json(self) -> dict[str, str]:

--- a/src/rpi_ai/models/chatbot.py
+++ b/src/rpi_ai/models/chatbot.py
@@ -61,7 +61,7 @@ class Chatbot:
         return Message(message=self.first_message.get("parts"))
 
     def send_message(self, text: str) -> Message:
-        response = self._chat.send_message(text)
+        response = self._chat.send_message([text])
 
         if commands := self._get_commands_from_response(response):
             if response_parts := self._get_response_parts_from_commands(commands):

--- a/tests/rpi_ai/function_calling/test_system_info.py
+++ b/tests/rpi_ai/function_calling/test_system_info.py
@@ -95,22 +95,6 @@ def mock_psutil_temperature() -> Generator[MagicMock, None, None]:
         yield mock
 
 
-@pytest.fixture
-def mock_psutil_fans() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.SystemInfo._psutil_fans") as mock:
-        mock.return_value = {"fan1": 1500}
-        yield mock
-
-
-@pytest.fixture
-def mock_psutil_battery() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.psutil.sensors_battery") as mock:
-        mock.return_value.percent = 80
-        mock.return_value.power_plugged = True
-        mock.return_value.secsleft = 3600
-        yield mock
-
-
 def test_get_os_info(mock_platform: dict) -> None:
     expected_result = {
         "system": "test_system",
@@ -169,17 +153,3 @@ def test_get_disk_usage(mock_disk_usage: MagicMock) -> None:
 
 def test_get_temperature(mock_psutil_temperature: MagicMock) -> None:
     assert SystemInfo.get_temperature() == mock_psutil_temperature.return_value
-
-
-def test_get_fan_speeds(mock_psutil_fans: MagicMock) -> None:
-    expected_result = mock_psutil_fans.return_value
-    assert SystemInfo.get_fan_speeds() == expected_result
-
-
-def test_get_battery_info(mock_psutil_battery: MagicMock) -> None:
-    expected_result = {
-        "percent": mock_psutil_battery.return_value.percent,
-        "power_plugged": mock_psutil_battery.return_value.power_plugged,
-        "secsleft": mock_psutil_battery.return_value.secsleft,
-    }
-    assert SystemInfo.get_battery_info() == expected_result

--- a/tests/rpi_ai/function_calling/test_system_info.py
+++ b/tests/rpi_ai/function_calling/test_system_info.py
@@ -95,6 +95,22 @@ def mock_psutil_temperature() -> Generator[MagicMock, None, None]:
         yield mock
 
 
+@pytest.fixture
+def mock_psutil_fans() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.function_calling.system_info.SystemInfo._psutil_fans") as mock:
+        mock.return_value = {"fan1": 1500}
+        yield mock
+
+
+@pytest.fixture
+def mock_psutil_battery() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.function_calling.system_info.psutil.sensors_battery") as mock:
+        mock.return_value.percent = 80
+        mock.return_value.power_plugged = True
+        mock.return_value.secsleft = 3600
+        yield mock
+
+
 def test_get_os_info(mock_platform: dict) -> None:
     expected_result = {
         "system": "test_system",
@@ -131,7 +147,7 @@ def test_cpu_percent(mock_cpu_percent: MagicMock) -> None:
     assert SystemInfo.get_cpu_percent() == mock_cpu_percent.return_value
 
 
-def test_memory_percent(mock_virtual_memory: MagicMock) -> None:
+def test_get_memory_usage(mock_virtual_memory: MagicMock) -> None:
     expected_result = {
         "total": mock_virtual_memory.return_value.total,
         "available": mock_virtual_memory.return_value.available,
@@ -141,7 +157,7 @@ def test_memory_percent(mock_virtual_memory: MagicMock) -> None:
     assert SystemInfo.get_memory_usage() == expected_result
 
 
-def test_disk_usage(mock_disk_usage: MagicMock) -> None:
+def test_get_disk_usage(mock_disk_usage: MagicMock) -> None:
     expected_result = {
         "total": mock_disk_usage.return_value.total,
         "used": mock_disk_usage.return_value.used,
@@ -151,5 +167,19 @@ def test_disk_usage(mock_disk_usage: MagicMock) -> None:
     assert SystemInfo.get_disk_usage() == expected_result
 
 
-def test_temperature(mock_psutil_temperature: MagicMock) -> None:
-    assert SystemInfo.temperature() == mock_psutil_temperature.return_value
+def test_get_temperature(mock_psutil_temperature: MagicMock) -> None:
+    assert SystemInfo.get_temperature() == mock_psutil_temperature.return_value
+
+
+def test_get_fan_speeds(mock_psutil_fans: MagicMock) -> None:
+    expected_result = {"fan1": 1500}
+    assert SystemInfo.get_fan_speeds() == expected_result
+
+
+def test_get_battery_info(mock_psutil_battery: MagicMock) -> None:
+    expected_result = {
+        "percent": 80,
+        "power_plugged": True,
+        "secsleft": 3600,
+    }
+    assert SystemInfo.get_battery_info() == expected_result

--- a/tests/rpi_ai/function_calling/test_system_info.py
+++ b/tests/rpi_ai/function_calling/test_system_info.py
@@ -172,14 +172,14 @@ def test_get_temperature(mock_psutil_temperature: MagicMock) -> None:
 
 
 def test_get_fan_speeds(mock_psutil_fans: MagicMock) -> None:
-    expected_result = {"fan1": 1500}
+    expected_result = mock_psutil_fans.return_value
     assert SystemInfo.get_fan_speeds() == expected_result
 
 
 def test_get_battery_info(mock_psutil_battery: MagicMock) -> None:
     expected_result = {
-        "percent": 80,
-        "power_plugged": True,
-        "secsleft": 3600,
+        "percent": mock_psutil_battery.return_value.percent,
+        "power_plugged": mock_psutil_battery.return_value.power_plugged,
+        "secsleft": mock_psutil_battery.return_value.secsleft,
     }
     assert SystemInfo.get_battery_info() == expected_result

--- a/tests/rpi_ai/function_calling/test_system_info.py
+++ b/tests/rpi_ai/function_calling/test_system_info.py
@@ -112,7 +112,7 @@ def test_os_info(mock_platform: dict) -> None:
         "machine": "armv7l",
         "processor": "ARMv7 Processor rev 4 (v7l)",
     }
-    assert SystemInfo.os_info() == str(expected_result)
+    assert SystemInfo.os_info() == expected_result
 
 
 def test_hostname(mock_hostname: MagicMock) -> None:
@@ -131,7 +131,7 @@ def test_get_running_processes(mock_process_iter: MagicMock) -> None:
     expected_result = {
         mock_process_iter.return_value[0].pid: {"pid": 1234, "name": "test_process", "username": "test_user"}
     }
-    assert SystemInfo.get_running_processes() == str(expected_result)
+    assert SystemInfo.get_running_processes() == expected_result
 
 
 def test_get_process_name_by_pid(mock_process: MagicMock) -> None:

--- a/tests/rpi_ai/function_calling/test_system_info.py
+++ b/tests/rpi_ai/function_calling/test_system_info.py
@@ -8,69 +8,6 @@ from rpi_ai.function_calling.system_info import SystemInfo
 
 
 @pytest.fixture
-def mock_cpu_percent() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.psutil.cpu_percent") as mock:
-        mock.return_value = 50.0
-        yield mock
-
-
-@pytest.fixture
-def mock_virtual_memory() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.psutil.virtual_memory") as mock:
-        mock.return_value.percent = 75.0
-        yield mock
-
-
-@pytest.fixture
-def mock_disk_usage() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.psutil.disk_usage") as mock:
-        mock.return_value.percent = 60.0
-        yield mock
-
-
-@pytest.fixture
-def mock_sensors_temperatures() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.SystemInfo._psutil_temperature") as mock:
-        mock.return_value = {"cpu_thermal": [Mock(current=45.0)]}
-        yield mock
-
-
-@pytest.fixture
-def mock_psutil_temperature() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.SystemInfo._psutil_temperature") as mock:
-        mock.return_value = 45.0
-        yield mock
-
-
-@pytest.fixture
-def mock_process_iter() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.psutil.process_iter") as mock:
-        mock.return_value = [Mock(info={"pid": 1234, "name": "test_process", "username": "test_user"})]
-        yield mock
-
-
-@pytest.fixture
-def mock_boot_time() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.psutil.boot_time") as mock:
-        mock.return_value = datetime.now().timestamp() - 3600  # 1 hour ago
-        yield mock
-
-
-@pytest.fixture
-def mock_hostname() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.socket.gethostname") as mock:
-        mock.return_value = "test_hostname"
-        yield mock
-
-
-@pytest.fixture
-def mock_ip_address() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.function_calling.system_info.socket.gethostbyname") as mock:
-        mock.return_value = "192.168.1.1"
-        yield mock
-
-
-@pytest.fixture
 def mock_platform() -> Generator[MagicMock, None, None]:
     with (
         patch("rpi_ai.function_calling.system_info.platform.system") as mock_system,
@@ -80,12 +17,12 @@ def mock_platform() -> Generator[MagicMock, None, None]:
         patch("rpi_ai.function_calling.system_info.platform.machine") as mock_machine,
         patch("rpi_ai.function_calling.system_info.platform.processor") as mock_processor,
     ):
-        mock_system.return_value = "Linux"
+        mock_system.return_value = "test_system"
         mock_node.return_value = "test_node"
-        mock_release.return_value = "5.10"
-        mock_version.return_value = "#1 SMP PREEMPT"
-        mock_machine.return_value = "armv7l"
-        mock_processor.return_value = "ARMv7 Processor rev 4 (v7l)"
+        mock_release.return_value = "test_release"
+        mock_version.return_value = "test_version"
+        mock_machine.return_value = "test_machine"
+        mock_processor.return_value = "test_processor"
         yield {
             "system": mock_system,
             "node": mock_node,
@@ -97,34 +34,85 @@ def mock_platform() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
+def mock_get_hostname() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.function_calling.system_info.socket.gethostname") as mock:
+        mock.return_value = "test_get_hostname"
+        yield mock
+
+
+@pytest.fixture
+def mock_boot_time() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.function_calling.system_info.psutil.boot_time") as mock:
+        mock.return_value = datetime.now().timestamp() - 3600  # 1 hour ago
+        yield mock
+
+
+@pytest.fixture
+def mock_process_iter() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.function_calling.system_info.psutil.process_iter") as mock:
+        mock.return_value = [Mock(info={"pid": 1234, "name": "test_process", "username": "test_user"})]
+        yield mock
+
+
+@pytest.fixture
 def mock_process() -> Generator[MagicMock, None, None]:
     with patch("rpi_ai.function_calling.system_info.psutil.Process") as mock:
         mock.return_value.name.return_value = "test_process"
         yield mock
 
 
-def test_os_info(mock_platform: dict) -> None:
+@pytest.fixture
+def mock_cpu_percent() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.function_calling.system_info.psutil.cpu_percent") as mock:
+        mock.return_value = 50.0
+        yield mock
+
+
+@pytest.fixture
+def mock_virtual_memory() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.function_calling.system_info.psutil.virtual_memory") as mock:
+        mock.return_value.total = 100
+        mock.return_value.available = 80
+        mock.return_value.used = 20
+        mock.return_value.percent = 20
+        yield mock
+
+
+@pytest.fixture
+def mock_disk_usage() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.function_calling.system_info.psutil.disk_usage") as mock:
+        mock.return_value.total = 100
+        mock.return_value.used = 80
+        mock.return_value.free = 20
+        mock.return_value.percent = 80
+        yield mock
+
+
+@pytest.fixture
+def mock_psutil_temperature() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.function_calling.system_info.SystemInfo._psutil_temperature") as mock:
+        mock.return_value = 45.0
+        yield mock
+
+
+def test_get_os_info(mock_platform: dict) -> None:
     expected_result = {
-        "system": "Linux",
+        "system": "test_system",
         "node": "test_node",
-        "release": "5.10",
-        "version": "#1 SMP PREEMPT",
-        "machine": "armv7l",
-        "processor": "ARMv7 Processor rev 4 (v7l)",
+        "release": "test_release",
+        "version": "test_version",
+        "machine": "test_machine",
+        "processor": "test_processor",
     }
-    assert SystemInfo.os_info() == expected_result
+    assert SystemInfo.get_os_info() == expected_result
 
 
-def test_hostname(mock_hostname: MagicMock) -> None:
-    assert SystemInfo.hostname() == "test_hostname"
+def test_get_hostname(mock_get_hostname: MagicMock) -> None:
+    assert SystemInfo.get_hostname() == "test_get_hostname"
 
 
-def test_ip_address(mock_ip_address: MagicMock) -> None:
-    assert SystemInfo.ip_address() == "192.168.1.1"
-
-
-def test_uptime(mock_boot_time: MagicMock) -> None:
-    assert "1:00:00" in SystemInfo.uptime()
+def test_get_uptime(mock_boot_time: MagicMock) -> None:
+    assert "1:00:00" in SystemInfo.get_uptime()
 
 
 def test_get_running_processes(mock_process_iter: MagicMock) -> None:
@@ -140,15 +128,27 @@ def test_get_process_name_by_pid(mock_process: MagicMock) -> None:
 
 
 def test_cpu_percent(mock_cpu_percent: MagicMock) -> None:
-    assert SystemInfo.cpu_percent() == mock_cpu_percent.return_value
+    assert SystemInfo.get_cpu_percent() == mock_cpu_percent.return_value
 
 
 def test_memory_percent(mock_virtual_memory: MagicMock) -> None:
-    assert SystemInfo.memory_percent() == mock_virtual_memory.return_value.percent
+    expected_result = {
+        "total": mock_virtual_memory.return_value.total,
+        "available": mock_virtual_memory.return_value.available,
+        "used": mock_virtual_memory.return_value.used,
+        "percent": mock_virtual_memory.return_value.percent,
+    }
+    assert SystemInfo.get_memory_usage() == expected_result
 
 
 def test_disk_usage(mock_disk_usage: MagicMock) -> None:
-    assert SystemInfo.disk_usage() == mock_disk_usage.return_value.percent
+    expected_result = {
+        "total": mock_disk_usage.return_value.total,
+        "used": mock_disk_usage.return_value.used,
+        "free": mock_disk_usage.return_value.free,
+        "percent": mock_disk_usage.return_value.percent,
+    }
+    assert SystemInfo.get_disk_usage() == expected_result
 
 
 def test_temperature(mock_psutil_temperature: MagicMock) -> None:

--- a/tests/rpi_ai/models/test_chatbot.py
+++ b/tests/rpi_ai/models/test_chatbot.py
@@ -133,7 +133,7 @@ class TestChatbot:
 
         mock_chatbot.start_chat()
         response = mock_chatbot.send_message(mock_msg)
-        mock_chat_instance.send_message.assert_called_once_with(mock_msg)
+        mock_chat_instance.send_message.assert_called_once_with([mock_msg])
         assert response.message == "Hi user!"
 
     def test_send_message_with_commands(
@@ -157,5 +157,5 @@ class TestChatbot:
 
         mock_chatbot.start_chat()
         response = mock_chatbot.send_message(mock_msg)
-        mock_chat_instance.send_message.assert_called_once_with(mock_msg)
+        mock_chat_instance.send_message.assert_called_once_with([mock_msg])
         assert response.message == "An error occurred! Please try again."

--- a/ui/lib/components/messages/message_input.dart
+++ b/ui/lib/components/messages/message_input.dart
@@ -67,6 +67,7 @@ class _MessageInputState extends State<MessageInput> {
 
     widget.messageType.handleAddMessage(messageState, userMessageDict);
     textController.clear();
+    scrollToBottom();
 
     Map<String, dynamic> message = await widget.messageType.sendMessage(
       httpHelper,


### PR DESCRIPTION
This pull request includes significant refactoring and improvements to the `SystemInfo` class and related tests in the `rpi_ai` module. The changes enhance the clarity of method names, return types, and test fixtures.

Refactoring and improvements:

* [`src/rpi_ai/function_calling/system_info.py`](diffhunk://#diff-c4448b3fde718b002499a6e8f02bb5aeeb1a391dc203ce1655f69d435cbfeb54L17-R61): Renamed methods to use a consistent `get_` prefix and updated return types to provide more detailed information. [[1]](diffhunk://#diff-c4448b3fde718b002499a6e8f02bb5aeeb1a391dc203ce1655f69d435cbfeb54L17-R61) [[2]](diffhunk://#diff-c4448b3fde718b002499a6e8f02bb5aeeb1a391dc203ce1655f69d435cbfeb54R70-R85) [[3]](diffhunk://#diff-c4448b3fde718b002499a6e8f02bb5aeeb1a391dc203ce1655f69d435cbfeb54L87-R152)
* [`src/rpi_ai/main.py`](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35R33-R34): Added logging for generated tokens in the `__init__` method.
* [`src/rpi_ai/models/chatbot.py`](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL64-R64): Modified the `send_message` method to send a list of messages instead of a single string.

Testing updates:

* [`tests/rpi_ai/function_calling/test_system_info.py`](diffhunk://#diff-ddc60858a4ada8a5a027c1de0d5495680a99bf3b2be089b93b99bcf2a5c4bc56L11-R46): Updated test fixtures and test cases to match the refactored method names and return types in `SystemInfo`. [[1]](diffhunk://#diff-ddc60858a4ada8a5a027c1de0d5495680a99bf3b2be089b93b99bcf2a5c4bc56L11-R46) [[2]](diffhunk://#diff-ddc60858a4ada8a5a027c1de0d5495680a99bf3b2be089b93b99bcf2a5c4bc56L53-R122) [[3]](diffhunk://#diff-ddc60858a4ada8a5a027c1de0d5495680a99bf3b2be089b93b99bcf2a5c4bc56L143-R155)
* [`tests/rpi_ai/models/test_chatbot.py`](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL136-R136): Adjusted tests to reflect the change in the `send_message` method to handle lists of messages. [[1]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL136-R136) [[2]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL160-R160)