### PR TITLE
Add waitress as a server for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,12 @@ To format the code:
     python -m ruff format .
 
 ## Installing and Running the API
-To install the API, download the release tarball and extract it. Then, run the `install_rpi_ai.sh` script:
+To install the API, download the release tarball and extract it.
+Before running the installer, ensure you have set the `GEMINI_API_KEY` environment variable.
+Run the `install_rpi_ai.sh` script:
 
     tar -xzf rpi_ai.tar.gz
     cd rpi_ai
-    export GEMINI_API_KEY=<Your API Key>
     ./install_rpi_ai.sh
 
 This script will create a virtual environment, install the API from the wheel file, and set up the necessary directories and files.
@@ -140,6 +141,8 @@ To stop the service, run the `stop_service.sh` script:
 To uninstall the API, run the `uninstall_rpi_ai.sh` script:
 
     ./uninstall_rpi_ai.sh
+    cd ..
+    rm -rf rpi_ai
 
 This will remove the virtual environment, executable, and all related files and directories.
 The folder can then safely be deleted.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "flask",
+    "waitress",
     "google-generativeai",
     "grpcio==1.60.1",
     "python-dotenv",

--- a/src/rpi_ai/main.py
+++ b/src/rpi_ai/main.py
@@ -6,6 +6,7 @@ from types import FrameType
 
 from dotenv import load_dotenv
 from flask import Flask, Response, jsonify, request
+from waitress import serve
 
 from rpi_ai.functions import FUNCTIONS
 from rpi_ai.models.chatbot import Chatbot
@@ -148,7 +149,7 @@ class AIApp:
 
     def run(self, host: str, port: int) -> None:
         signal.signal(signal.SIGINT, self.shutdown_handler)
-        self.app.run(host=host, port=port)
+        serve(self.app, host=host, port=port)
 
 
 def main() -> None:

--- a/tests/rpi_ai/conftest.py
+++ b/tests/rpi_ai/conftest.py
@@ -209,3 +209,9 @@ def mock_ai_app(
 def mock_client(mock_ai_app: AIApp) -> Generator[FlaskClient, None, None]:
     with mock_ai_app.app.test_client() as client:
         yield client
+
+
+@pytest.fixture
+def mock_waitress_serve() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.main.serve") as mock:
+        yield mock

--- a/tests/rpi_ai/test_main.py
+++ b/tests/rpi_ai/test_main.py
@@ -177,6 +177,10 @@ class TestAIApp:
         mock_jsonify.assert_called_once_with({"error": "Unauthorized"})
         assert response.status_code == UNAUTHORIZED_CODE
 
+    def test_run_with_waitress(self, mock_ai_app: AIApp, mock_waitress_serve: MagicMock) -> None:
+        mock_ai_app.run(host="0.0.0.0", port=8080)
+        mock_waitress_serve.assert_called_once_with(mock_ai_app.app, host="0.0.0.0", port=8080)
+
 
 def test_main(mock_ai_app_class: MagicMock) -> None:
     main()


### PR DESCRIPTION
This pull request introduces the `waitress` WSGI server to replace Flask's built-in server for production environments. The changes include updating dependencies, modifying the application startup logic, and adding tests to ensure the new server is properly integrated.

### Dependency Update:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R23): Added `waitress` to the list of dependencies.

### Application Logic Changes:
* [`src/rpi_ai/main.py`](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35R9): Imported `waitress` and updated the `run` method to use `waitress.serve` instead of `self.app.run`. [[1]](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35R9) [[2]](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35L151-R152)

### Testing Enhancements:
* [`tests/rpi_ai/conftest.py`](diffhunk://#diff-3af729e32e4270155008c31b1a85406218bdf36d989cc683c325746b68ef6f13R212-R217): Added a new pytest fixture `mock_waitress_serve` to mock the `waitress.serve` function.
* [`tests/rpi_ai/test_main.py`](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786R180-R183): Added a test `test_run_with_waitress` to verify that `waitress.serve` is called with the correct parameters.