### PR TITLE
Change Gemini SDK

### DIFF
--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -34,7 +34,7 @@ jobs:
           pip install -e .[dev]
       - name: Test with pytest
         run: |
-          python -m pytest
+          python -m pytest --cov-report html
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ addopts = [
     "--cov",
     "--cov-report",
     "term-missing",
-    "--cov-report",
-    "html",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ classifiers = [
 dependencies = [
     "flask",
     "waitress",
-    "google-generativeai",
-    "grpcio==1.60.1",
+    "google-genai",
     "gTTS",
     "python-dotenv",
     "pydantic",

--- a/src/rpi_ai/function_calling/system_info.py
+++ b/src/rpi_ai/function_calling/system_info.py
@@ -134,16 +134,6 @@ class SystemInfo(FunctionsListBase):
         }
 
     @staticmethod
-    def _psutil_temperature() -> float:
-        """
-        Get the CPU temperature using `psutil`.
-
-        Returns:
-            float: The CPU temperature in degrees Celsius.
-        """
-        return psutil.sensors_temperatures()["cpu_thermal"][0].current
-
-    @staticmethod
     def get_temperature() -> float:
         """
         Get the CPU temperature in degrees Celsius.
@@ -153,6 +143,6 @@ class SystemInfo(FunctionsListBase):
             `None` is returned if the temperature cannot be retrieved.
         """
         try:
-            return SystemInfo._psutil_temperature()
+            return psutil.sensors_temperatures()["cpu_thermal"][0].current
         except (KeyError, IndexError, AttributeError):
             logger.exception("Failed to get CPU temperature.")

--- a/src/rpi_ai/models/audiobot.py
+++ b/src/rpi_ai/models/audiobot.py
@@ -1,15 +1,16 @@
 import base64
 from io import BytesIO
 
+from google.genai.types import Part
 from gtts import gTTS
 
 
-def get_request_body_from_audio(audio_data: bytes) -> dict[str, str]:
-    inline_data = {
-        "mime_type": "audio/ogg",
-        "data": audio_data,
-    }
-    return {"parts": [{"inline_data": inline_data}]}
+def get_audio_request(audio_data: bytes) -> dict[str, str]:
+    inline_data = Part.from_bytes(
+        data=audio_data,
+        mime_type="audio/mp3",
+    )
+    return ["Respond to the voice message.", inline_data]
 
 
 def get_audio_bytes_from_text(text: str) -> str:

--- a/src/rpi_ai/models/chatbot.py
+++ b/src/rpi_ai/models/chatbot.py
@@ -79,15 +79,8 @@ class Chatbot:
             return Message(message="An error occurred! Please try again.")
 
     def send_audio(self, audio_data: bytes) -> SpeechResponse:
-        response = self._chat.send_message(
-            [
-                "Respond to the following voice message:",
-                Part.from_bytes(
-                    data=audio_data,
-                    mime_type="audio/mp3",
-                ),
-            ]
-        )
+        audio_request = audiobot.get_audio_request(audio_data)
+        response = self._chat.send_message(audio_request)
 
         response = self._handle_commands(response)
 

--- a/src/rpi_ai/models/chatbot.py
+++ b/src/rpi_ai/models/chatbot.py
@@ -23,13 +23,9 @@ class Chatbot:
 
     def _get_commands_from_response(self, response: GenerateContentResponse) -> Iterable[FunctionTool]:
         commands: Iterable[FunctionResponse] = []
-        try:
-            for candidate in response.candidates:
-                for part in candidate.content.parts:
-                    if command := self._extract_command_from_part(part):
-                        commands.append(command)
-        except AttributeError:
-            return []
+        for part in response.candidates[0].content.parts:
+            if command := self._extract_command_from_part(part):
+                commands.append(command)
         return commands
 
     def _get_response_parts_from_commands(self, commands: Iterable[FunctionTool]) -> list[Part]:

--- a/src/rpi_ai/types.py
+++ b/src/rpi_ai/types.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 
-from google.generativeai.protos import FunctionCall
-from google.generativeai.types import GenerationConfig
+from google.genai.types import FunctionCall
 from pydantic.dataclasses import dataclass
 
 
@@ -21,14 +20,6 @@ class AIConfigType:
     def load(cls, path: str) -> AIConfigType:
         with open(path) as file:
             return cls(**json.load(file))
-
-    @property
-    def generation_config(self) -> GenerationConfig:
-        return GenerationConfig(
-            candidate_count=self.candidate_count,
-            max_output_tokens=self.max_output_tokens,
-            temperature=self.temperature,
-        )
 
 
 # Chatbot responses

--- a/src/rpi_ai/types.py
+++ b/src/rpi_ai/types.py
@@ -30,26 +30,11 @@ class Message:
 
     @classmethod
     def from_dict(cls, data: dict[str, str]) -> Message:
-        parts = Message.extract_parts(data).strip()
-        is_user = Message.is_user(data)
-        return cls(parts, is_user)
-
-    @staticmethod
-    def extract_parts(data: dict[str, str]) -> str:
-        return "".join([part.text for part in data["parts"]])
+        return cls(message=data["parts"], is_user_message=cls.is_user(data))
 
     @staticmethod
     def is_user(data: dict[str, str]) -> bool:
         return data["role"] == "user"
-
-
-@dataclass
-class MessageList:
-    messages: list[Message]
-
-    @classmethod
-    def from_history(cls, data: list[dict[str, str]]) -> MessageList:
-        return cls([Message.from_dict(item) for item in data])
 
 
 @dataclass

--- a/tests/rpi_ai/conftest.py
+++ b/tests/rpi_ai/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from flask.testing import FlaskClient
-from google.generativeai.protos import FunctionCall, Part
+from google.genai.types import FunctionCall, Part
 
 from rpi_ai.main import AIApp
 from rpi_ai.models.chatbot import Chatbot

--- a/tests/rpi_ai/conftest.py
+++ b/tests/rpi_ai/conftest.py
@@ -67,13 +67,6 @@ def mock_response_command_with_args() -> MagicMock:
     return mock_response
 
 
-# Types fixtures
-@pytest.fixture
-def mock_extract_parts() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.types.Message.extract_parts") as mock:
-        yield mock
-
-
 # Chatbot fixtures
 @pytest.fixture
 def mock_genai_client() -> Generator[MagicMock, None, None]:
@@ -87,12 +80,6 @@ def mock_start_chat_method(mock_genai_client: MagicMock) -> MagicMock:
     mock_genai_client.return_value.chats.create.return_value = mock_chat_instance
     mock_chat_instance.send_message.return_value = MagicMock(parts=[MagicMock(text="What's on your mind today?")])
     return mock_genai_client.return_value.chats.create
-
-
-@pytest.fixture
-def mock_generate_content(mock_genai_client: MagicMock) -> MagicMock:
-    mock_genai_client.return_value.generate_content.return_value = MagicMock()
-    return mock_genai_client.return_value.generate_content
 
 
 @pytest.fixture

--- a/tests/rpi_ai/conftest.py
+++ b/tests/rpi_ai/conftest.py
@@ -72,8 +72,8 @@ def mock_extract_parts() -> Generator[MagicMock, None, None]:
 
 # Chatbot fixtures
 @pytest.fixture
-def mock_genai_configure() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.models.chatbot.genai.configure") as mock:
+def mock_genai_client() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.models.chatbot.Client") as mock:
         yield mock
 
 

--- a/tests/rpi_ai/conftest.py
+++ b/tests/rpi_ai/conftest.py
@@ -53,14 +53,18 @@ def mock_functions_list() -> FunctionToolList:
 def mock_response_command_without_args() -> MagicMock:
     mock_function_call = FunctionCall(name=function_without_args.__name__, args={})
     mock_part = Part(function_call=mock_function_call)
-    return MagicMock(parts=[mock_part])
+    mock_response = MagicMock()
+    mock_response.candidates = [MagicMock(content=MagicMock(parts=[mock_part]))]
+    return mock_response
 
 
 @pytest.fixture
 def mock_response_command_with_args() -> MagicMock:
-    mock_function_call = FunctionCall(name=function_with_args.__name__, args={})
+    mock_function_call = FunctionCall(name=function_with_args.__name__, args={"data": "test"})
     mock_part = Part(function_call=mock_function_call)
-    return MagicMock(parts=[mock_part])
+    mock_response = MagicMock()
+    mock_response.candidates = [MagicMock(content=MagicMock(parts=[mock_part]))]
+    return mock_response
 
 
 # Types fixtures
@@ -78,28 +82,23 @@ def mock_genai_client() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_generative_model() -> Generator[MagicMock, None, None]:
-    with patch("rpi_ai.models.chatbot.genai.GenerativeModel") as mock:
-        yield mock
-
-
-@pytest.fixture
-def mock_start_chat_method(mock_generative_model: MagicMock) -> MagicMock:
+def mock_start_chat_method(mock_genai_client: MagicMock) -> MagicMock:
     mock_chat_instance = MagicMock()
-    mock_generative_model.return_value.start_chat.return_value = mock_chat_instance
-    return mock_generative_model.return_value.start_chat
+    mock_genai_client.return_value.chats.create.return_value = mock_chat_instance
+    mock_chat_instance.send_message.return_value = MagicMock(parts=[MagicMock(text="What's on your mind today?")])
+    return mock_genai_client.return_value.chats.create
 
 
 @pytest.fixture
-def mock_generate_content(mock_generative_model: MagicMock) -> MagicMock:
-    mock_generative_model.return_value.generate_content.return_value = MagicMock()
-    return mock_generative_model.return_value.generate_content
+def mock_generate_content(mock_genai_client: MagicMock) -> MagicMock:
+    mock_genai_client.return_value.generate_content.return_value = MagicMock()
+    return mock_genai_client.return_value.generate_content
 
 
 @pytest.fixture
 def mock_chat_instance(mock_start_chat_method: MagicMock) -> MagicMock:
     mock_chat_instance = MagicMock()
-    mock_chat_instance.history = [MagicMock(role="model", parts=[MagicMock(text="What's on your mind today")])]
+    mock_chat_instance.history = [MagicMock(role="model", parts=[MagicMock(text="What's on your mind today?")])]
     mock_start_chat_method.return_value = mock_chat_instance
     return mock_chat_instance
 
@@ -109,7 +108,7 @@ def mock_chatbot(
     mock_app_path: MagicMock,
     mock_api_key: MagicMock,
     mock_config: AIConfigType,
-    mock_genai_configure: MagicMock,
+    mock_genai_client: MagicMock,
     mock_chat_instance: MagicMock,
     mock_functions_list: FunctionToolList,
 ) -> Chatbot:

--- a/tests/rpi_ai/function_calling/test_functions_list_base.py
+++ b/tests/rpi_ai/function_calling/test_functions_list_base.py
@@ -27,6 +27,8 @@ class TestFunctionsListBase:
             return "dummy"
 
         flb.functions.append(dummy_function)
+        assert len(flb.functions) == 1
+        assert flb.functions[0]() == "dummy"
         flb.functions.remove(dummy_function)
         assert len(flb.functions) == 0
 
@@ -37,5 +39,7 @@ class TestFunctionsListBase:
             return "dummy"
 
         flb.functions.append(dummy_function)
+        assert len(flb.functions) == 1
+        assert flb.functions[0]() == "dummy"
         flb.functions.clear()
         assert len(flb.functions) == 0

--- a/tests/rpi_ai/models/test_audiobot.py
+++ b/tests/rpi_ai/models/test_audiobot.py
@@ -2,22 +2,21 @@ import base64
 from io import BytesIO
 from unittest.mock import MagicMock
 
-from rpi_ai.models.audiobot import get_audio_bytes_from_text, get_request_body_from_audio
+from google.genai.types import Part
+
+from rpi_ai.models.audiobot import get_audio_bytes_from_text, get_audio_request
 
 
-def test_get_request_body_from_audio() -> None:
+def test_get_audio_request() -> None:
     audio_data = b"test_audio_data"
-    expected_result = {
-        "parts": [
-            {
-                "inline_data": {
-                    "mime_type": "audio/ogg",
-                    "data": audio_data,
-                }
-            }
-        ]
-    }
-    result = get_request_body_from_audio(audio_data)
+    expected_result = [
+        "Respond to the voice message.",
+        Part.from_bytes(
+            data=audio_data,
+            mime_type="audio/mp3",
+        ),
+    ]
+    result = get_audio_request(audio_data)
     assert result == expected_result
 
 

--- a/tests/rpi_ai/models/test_chatbot.py
+++ b/tests/rpi_ai/models/test_chatbot.py
@@ -8,25 +8,8 @@ from rpi_ai.types import AIConfigType, FunctionTool, FunctionToolList
 
 
 class TestChatbot:
-    def test_init(
-        self,
-        mock_chatbot: Chatbot,
-        mock_config: AIConfigType,
-        mock_api_key: MagicMock,
-        mock_genai_configure: MagicMock,
-        mock_generative_model: MagicMock,
-    ) -> None:
-        mock_genai_configure.assert_called_once_with(api_key=mock_api_key.return_value)
-        mock_generative_model.assert_called_once_with(
-            model_name=mock_config.model,
-            system_instruction=mock_config.system_instruction,
-            generation_config=mock_config.generation_config,
-            tools=mock_chatbot._functions.functions,
-        )
-
-    def test_first_message(self, mock_chatbot: Chatbot) -> None:
-        assert mock_chatbot.first_message["role"] == "model"
-        assert isinstance(mock_chatbot.first_message["parts"], str)
+    def test_init(self, mock_chatbot: Chatbot, mock_api_key: MagicMock, mock_genai_client: MagicMock) -> None:
+        mock_genai_client.assert_called_once_with(api_key=mock_api_key.return_value)
 
     def test_extract_command_without_args_from_part_with_valid_function(
         self,

--- a/tests/rpi_ai/models/test_chatbot.py
+++ b/tests/rpi_ai/models/test_chatbot.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from google.generativeai.protos import FunctionCall
+from google.genai.types import FunctionCall, GenerateContentConfig
 from gtts import gTTSError
 
 from rpi_ai.models.chatbot import Chatbot
@@ -17,7 +17,7 @@ class TestChatbot:
         mock_functions_list: FunctionToolList,
         mock_response_command_without_args: MagicMock,
     ) -> None:
-        part = mock_response_command_without_args.parts[0]
+        part = mock_response_command_without_args.candidates[0].content.parts[0]
         command = mock_chatbot._extract_command_from_part(part)
 
         assert command is not None
@@ -27,7 +27,7 @@ class TestChatbot:
     def test_extract_command_with_args_from_part_with_valid_function(
         self, mock_chatbot: Chatbot, mock_functions_list: FunctionToolList, mock_response_command_with_args: MagicMock
     ) -> None:
-        part = mock_response_command_with_args.parts[0]
+        part = mock_response_command_with_args.candidates[0].content.parts[0]
         command = mock_chatbot._extract_command_from_part(part)
 
         assert command is not None
@@ -50,7 +50,7 @@ class TestChatbot:
         commands = list(mock_chatbot._get_commands_from_response(mock_response_command_without_args))
         assert len(commands) == 1
 
-        function_name = mock_response_command_without_args.parts[0].function_call.name
+        function_name = mock_response_command_without_args.candidates[0].content.parts[0].function_call.name
         assert commands[0].name == function_name
         assert commands[0].callable_fn == mock_functions_list[function_name]
 
@@ -60,10 +60,13 @@ class TestChatbot:
         commands = list(mock_chatbot._get_commands_from_response(mock_response_command_with_args))
         assert len(commands) == 1
 
-        function_name = mock_response_command_with_args.parts[0].function_call.name
+        function_name = mock_response_command_with_args.candidates[0].content.parts[0].function_call.name
         assert commands[0].name == function_name
         assert commands[0].callable_fn == mock_functions_list[function_name]
-        assert commands[0].function.args == mock_response_command_with_args.parts[0].function_call.args
+        assert (
+            commands[0].function.args
+            == mock_response_command_with_args.candidates[0].content.parts[0].function_call.args
+        )
 
     def test_get_response_parts_from_commands_with_valid_commands(
         self, mock_chatbot: Chatbot, mock_functions_list: FunctionToolList
@@ -100,14 +103,14 @@ class TestChatbot:
     def test_handle_commands_with_no_commands(
         self, mock_chatbot: Chatbot, mock_response_command_without_args: MagicMock
     ) -> None:
-        mock_response_command_without_args.parts = []
+        mock_response_command_without_args.candidates[0].content.parts = []
         response = mock_chatbot._handle_commands(mock_response_command_without_args)
         assert response == mock_response_command_without_args
 
     def test_handle_commands_with_invalid_commands(
         self, mock_chatbot: Chatbot, mock_response_command_without_args: MagicMock
     ) -> None:
-        mock_response_command_without_args.parts[0].function_call = None
+        mock_response_command_without_args.candidates[0].content.parts[0].function_call = None
         response = mock_chatbot._handle_commands(mock_response_command_without_args)
         assert response == mock_response_command_without_args
 
@@ -115,31 +118,36 @@ class TestChatbot:
         assert mock_chatbot.get_config() == mock_config
 
     def test_update_config(
-        self, mock_chatbot: Chatbot, mock_config: AIConfigType, mock_generative_model: MagicMock
+        self,
+        mock_chatbot: Chatbot,
+        mock_config: AIConfigType,
     ) -> None:
         mock_config.model = "new-model"
         mock_chatbot.update_config(mock_config)
-        mock_generative_model.assert_called_with(
-            model_name="new-model",
-            system_instruction=mock_config.system_instruction,
-            generation_config=mock_config.generation_config,
-            tools=mock_chatbot._functions.functions,
-        )
+        assert mock_chatbot.get_config() == mock_config
 
     def test_start_chat(self, mock_chatbot: Chatbot, mock_start_chat_method: MagicMock) -> None:
         response = mock_chatbot.start_chat()
-        mock_start_chat_method.assert_called_once_with(history=[mock_chatbot.first_message])
-        assert response.message == mock_chatbot.first_message["parts"]
+        mock_start_chat_method.assert_called_once_with(
+            model=mock_chatbot._config.model,
+            config=GenerateContentConfig(
+                system_instruction=mock_chatbot._config.system_instruction,
+                candidate_count=mock_chatbot._config.candidate_count,
+                max_output_tokens=mock_chatbot._config.max_output_tokens,
+                temperature=mock_chatbot._config.temperature,
+                tools=mock_chatbot._functions.functions,
+            ),
+        )
+        assert response.message == "What's on your mind today?"
 
     def test_send_message_with_valid_response(self, mock_chatbot: Chatbot, mock_chat_instance: MagicMock) -> None:
         mock_msg = "Hi model!"
-        mock_response = MagicMock()
-        mock_response.parts = [MagicMock(text="Hi user!")]
+        mock_response = MagicMock(text="Hi user!")
         mock_chat_instance.send_message.return_value = mock_response
 
         mock_chatbot.start_chat()
         response = mock_chatbot.send_message(mock_msg)
-        mock_chat_instance.send_message.assert_called_once_with([mock_msg])
+        mock_chat_instance.send_message.assert_called_once_with(mock_msg)
         assert response.message == "Hi user!"
 
     def test_send_message_with_commands(
@@ -148,7 +156,7 @@ class TestChatbot:
         mock_msg = "Hi model!"
         mock_responses = [
             mock_response_command_without_args,
-            MagicMock(parts=[MagicMock(text="Command executed")]),
+            MagicMock(text="Command executed"),
         ]
         mock_chat_instance.send_message.side_effect = mock_responses
 
@@ -163,14 +171,14 @@ class TestChatbot:
 
         mock_chatbot.start_chat()
         response = mock_chatbot.send_message(mock_msg)
-        mock_chat_instance.send_message.assert_called_once_with([mock_msg])
+        mock_chat_instance.send_message.assert_called_once_with(mock_msg)
         assert response.message == "An error occurred! Please try again."
 
     def test_send_audio_with_valid_response(
         self, mock_chatbot: Chatbot, mock_chat_instance: MagicMock, mock_get_audio_bytes_from_text: MagicMock
     ) -> None:
         mock_response = MagicMock()
-        mock_response.parts = [MagicMock(text="Hi user!")]
+        mock_response = MagicMock(text="Hi user!")
         mock_chat_instance.send_message.return_value = mock_response
 
         mock_audio = "test_audio_response"

--- a/tests/rpi_ai/test_types.py
+++ b/tests/rpi_ai/test_types.py
@@ -16,13 +16,6 @@ class TestAIConfigType:
             assert config.max_output_tokens == config_data["max_output_tokens"]
             assert config.temperature == config_data["temperature"]
 
-    def test_generation_config(self, config_data: dict[str, str | float]) -> None:
-        config = AIConfigType(**config_data)
-        gen_config = config.generation_config
-        assert gen_config.candidate_count == config_data["candidate_count"]
-        assert gen_config.max_output_tokens == config_data["max_output_tokens"]
-        assert gen_config.temperature == config_data["temperature"]
-
 
 # Chatbot responses
 class TestMessage:

--- a/tests/rpi_ai/test_types.py
+++ b/tests/rpi_ai/test_types.py
@@ -1,7 +1,7 @@
 import json
 from unittest.mock import mock_open, patch
 
-from google.generativeai.protos import FunctionCall
+from google.genai.types import FunctionCall
 
 from rpi_ai.types import AIConfigType, FunctionTool, FunctionToolList, Message, SpeechResponse
 

--- a/tests/rpi_ai/test_types.py
+++ b/tests/rpi_ai/test_types.py
@@ -1,9 +1,9 @@
 import json
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import mock_open, patch
 
 from google.generativeai.protos import FunctionCall
 
-from rpi_ai.types import AIConfigType, FunctionTool, FunctionToolList, Message, MessageList, SpeechResponse
+from rpi_ai.types import AIConfigType, FunctionTool, FunctionToolList, Message, SpeechResponse
 
 
 # Config
@@ -19,34 +19,17 @@ class TestAIConfigType:
 
 # Chatbot responses
 class TestMessage:
-    def test_from_dict_user_message(self, mock_extract_parts: MagicMock) -> None:
+    def test_from_dict_user_message(self) -> None:
         data = {"role": "user", "parts": "Hello, world!"}
-        mock_extract_parts.return_value = data["parts"]
         message = Message.from_dict(data)
         assert message.message == "Hello, world!"
         assert message.is_user_message
 
-    def test_from_dict_model_message(self, mock_extract_parts: MagicMock) -> None:
+    def test_from_dict_model_message(self) -> None:
         data = {"role": "model", "parts": "Hello, user!"}
-        mock_extract_parts.return_value = data["parts"]
         message = Message.from_dict(data)
         assert message.message == "Hello, user!"
         assert not message.is_user_message
-
-
-class TestMessageList:
-    def test_from_history(self, mock_extract_parts: MagicMock) -> None:
-        data = [
-            {"role": "user", "parts": "Hello, world!"},
-            {"role": "model", "parts": "Hello, user!"},
-        ]
-        mock_extract_parts.side_effect = [data[0]["parts"], data[1]["parts"]]
-        message_list = MessageList.from_history(data)
-        assert len(message_list.messages) == len(data)
-        assert message_list.messages[0].message == "Hello, world!"
-        assert message_list.messages[0].is_user_message
-        assert message_list.messages[1].message == "Hello, user!"
-        assert not message_list.messages[1].is_user_message
 
 
 class TestSpeechResponse:
@@ -88,21 +71,12 @@ class TestFunctionTool:
 class TestFunctionToolList:
     def test_dictionary(self) -> None:
         def fn1() -> None:
-            pass
+            return "fn1"
 
         def fn2() -> None:
-            pass
+            return "fn2"
 
         functions_list = FunctionToolList([fn1, fn2])
         assert functions_list.dictionary == {"fn1": fn1, "fn2": fn2}
-
-    def test_getitem(self) -> None:
-        def fn1() -> None:
-            pass
-
-        def fn2() -> None:
-            pass
-
-        functions_list = FunctionToolList([fn1, fn2])
-        assert functions_list["fn1"] == fn1
-        assert functions_list["fn2"] == fn2
+        assert functions_list["fn1"]() == "fn1"
+        assert functions_list["fn2"]() == "fn2"


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and integration of the chatbot and audio bot systems, as well as updates to dependencies and tests. The most important changes include switching from `google-generativeai` to `google-genai`, refactoring the chatbot and audio bot models, and updating the tests to reflect these changes.

### Dependency Updates:
* Updated `pyproject.toml` to replace `google-generativeai` with `google-genai`.

### Code Refactoring:
* Refactored `Chatbot` class in `src/rpi_ai/models/chatbot.py` to use `google.genai.Client` instead of `google.generativeai`. [[1]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL3-R4) [[2]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL15-L30)
* Refactored `get_audio_request` function in `src/rpi_ai/models/audiobot.py` to use `google.genai.types.Part`.

### Test Updates:
* Updated tests in `tests/rpi_ai/conftest.py` to mock `google.genai.Client` instead of `google.generativeai`. [[1]](diffhunk://#diff-3af729e32e4270155008c31b1a85406218bdf36d989cc683c325746b68ef6f13L56-R88) [[2]](diffhunk://#diff-3af729e32e4270155008c31b1a85406218bdf36d989cc683c325746b68ef6f13L112-R98)
* Updated tests in `tests/rpi_ai/models/test_chatbot.py` to reflect changes in the `Chatbot` class. [[1]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL3-R20) [[2]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL47-R30)

### Minor Changes:
* Removed the `_psutil_temperature` method in `src/rpi_ai/function_calling/system_info.py` and updated the `get_temperature` method to directly use `psutil.sensors_temperatures()`. [[1]](diffhunk://#diff-c4448b3fde718b002499a6e8f02bb5aeeb1a391dc203ce1655f69d435cbfeb54L136-L145) [[2]](diffhunk://#diff-c4448b3fde718b002499a6e8f02bb5aeeb1a391dc203ce1655f69d435cbfeb54L156-R146)
* Updated `pytest` configuration in `pyproject.toml` to remove redundant `--cov-report html` entry.