### PR TITLE
Improve API key handling in installation script and main application

### DIFF
--- a/release/install_rpi_ai.sh
+++ b/release/install_rpi_ai.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -eu
 
-if [ -z "${GEMINI_API_KEY}" ]; then
-    echo "GEMINI_API_KEY environment variable is not set. Please set it before running the script."
-    exit 1
+if [ -z "${GEMINI_API_KEY:-}" ]; then
+    read -p "(Gemini) Enter Gemini API key: " GEMINI_API_KEY
 fi
 
 WD=$(pwd)
@@ -145,7 +144,6 @@ cat > "${README_PATH}" << EOF
 RPi-AI has been installed successfully.
 The AI executable is located at: '${EXE_PATH}'
 Configure the AI model: '${CONFIG_PATH}'
-Add the following line to your '.bashrc' file: 'export GEMINI_API_KEY=<Your API Key>'
 
 To create a start-up service for the AI, run: './service/${CREATE_SERVICE_FILE}'
 To stop the service, run: './service/${STOP_SERVICE_FILE}'

--- a/src/rpi_ai/main.py
+++ b/src/rpi_ai/main.py
@@ -50,7 +50,7 @@ class AIApp:
         try:
             return Path(self._root_dir)
         except AttributeError:
-            self._root_dir = Path(os.environ.get("RPI_AI_PATH"))
+            self._root_dir = Path(str(os.environ.get("RPI_AI_PATH")))
             logger.debug(f"Root directory: {self._root_dir}")
             return self._root_dir
 
@@ -67,7 +67,7 @@ class AIApp:
         try:
             return self._api_key
         except AttributeError:
-            self._api_key = os.environ.get("GEMINI_API_KEY")
+            self._api_key = str(os.environ.get("GEMINI_API_KEY"))
             logger.debug("Successfully loaded API key")
             return self._api_key
 


### PR DESCRIPTION
This pull request includes updates to the `release/install_rpi_ai.sh` script and `src/rpi_ai/main.py` to improve user experience and error handling. The most important changes include prompting the user for the Gemini API key if it is not set, removing instructions to manually add the API key to `.bashrc`, and ensuring environment variables are correctly converted to strings.

Improvements to user experience:

* [`release/install_rpi_ai.sh`](diffhunk://#diff-cd469ebe3a3253b97fb517b7c4051f0fa086c41322f5ec76d5ed8521dd191cc9L4-R5): Modified the script to prompt the user for the Gemini API key if it is not set, instead of exiting with an error.
* [`release/install_rpi_ai.sh`](diffhunk://#diff-cd469ebe3a3253b97fb517b7c4051f0fa086c41322f5ec76d5ed8521dd191cc9L148): Removed the instruction to manually add the API key to the `.bashrc` file.

Error handling improvements:

* [`src/rpi_ai/main.py`](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35L53-R53): Ensured that the `RPI_AI_PATH` environment variable is converted to a string before creating a `Path` object.
* [`src/rpi_ai/main.py`](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35L70-R70): Ensured that the `GEMINI_API_KEY` environment variable is converted to a string before being used.