### PR TITLE
Fix audio endpoint

### DIFF
--- a/src/rpi_ai/models/audiobot.py
+++ b/src/rpi_ai/models/audiobot.py
@@ -15,6 +15,6 @@ def get_audio_request(audio_data: bytes) -> list[str | Part]:
 
 def get_audio_bytes_from_text(text: str) -> str:
     audio_fp = BytesIO()
-    tts = gTTS(text, lang="en", tld="com.au")
+    tts = gTTS(text, lang="en", tld="co.uk")
     tts.write_to_fp(audio_fp)
     return base64.b64encode(audio_fp.getvalue()).decode("utf-8")

--- a/src/rpi_ai/models/audiobot.py
+++ b/src/rpi_ai/models/audiobot.py
@@ -5,12 +5,12 @@ from google.genai.types import Part
 from gtts import gTTS
 
 
-def get_audio_request(audio_data: bytes) -> tuple[str, Part]:
+def get_audio_request(audio_data: bytes) -> list[str | Part]:
     inline_data = Part.from_bytes(
         data=audio_data,
         mime_type="audio/mp3",
     )
-    return "Respond to the voice message.", inline_data
+    return ["Respond to the voice message.", inline_data]
 
 
 def get_audio_bytes_from_text(text: str) -> str:

--- a/tests/rpi_ai/models/test_audiobot.py
+++ b/tests/rpi_ai/models/test_audiobot.py
@@ -9,13 +9,13 @@ from rpi_ai.models.audiobot import get_audio_bytes_from_text, get_audio_request
 
 def test_get_audio_request() -> None:
     audio_data = b"test_audio_data"
-    expected_result = (
+    expected_result = [
         "Respond to the voice message.",
         Part.from_bytes(
             data=audio_data,
             mime_type="audio/mp3",
         ),
-    )
+    ]
     result = get_audio_request(audio_data)
     assert result == expected_result
 

--- a/tests/rpi_ai/models/test_audiobot.py
+++ b/tests/rpi_ai/models/test_audiobot.py
@@ -31,5 +31,5 @@ def test_get_audio_bytes_from_text(mock_gtts: MagicMock) -> None:
     result = get_audio_bytes_from_text(text)
     expected_result = base64.b64encode(b"test_audio_bytes").decode("utf-8")
     assert result == expected_result
-    mock_gtts.assert_called_once_with(text, lang="en", tld="com.au")
+    mock_gtts.assert_called_once_with(text, lang="en", tld="co.uk")
     mock_gtts_instance.write_to_fp.assert_called_once()


### PR DESCRIPTION
This pull request includes changes to the `audiobot` model and its corresponding tests to improve type consistency and update language settings.

Changes to `audiobot` model:

* Modified the return type of `get_audio_request` from a tuple to a list for better type consistency.
* Updated the text-to-speech language setting from "com.au" to "co.uk" in `get_audio_bytes_from_text` to reflect a different regional accent.

Changes to tests:

* Updated the expected result in `test_get_audio_request` to match the new list return type from the `get_audio_request` function.