### PR TITLE
Add preprocessing functions to TTS

### DIFF
--- a/src/rpi_ai/models/audiobot.py
+++ b/src/rpi_ai/models/audiobot.py
@@ -1,8 +1,10 @@
 import base64
+from collections.abc import Callable
 from io import BytesIO
 
 from google.genai.types import Part
 from gtts import gTTS
+from gtts.tokenizer import pre_processors
 
 
 def get_audio_request(audio_data: bytes) -> list[str | Part]:
@@ -15,6 +17,32 @@ def get_audio_request(audio_data: bytes) -> list[str | Part]:
 
 def get_audio_bytes_from_text(text: str) -> str:
     audio_fp = BytesIO()
-    tts = gTTS(text, lang="en", tld="co.uk")
+    tts = gTTS(
+        text,
+        lang="en",
+        tld="co.uk",
+        pre_processor_funcs=[
+            *preprocess_default_list(),
+            preprocess_remove_asterisk,
+            preprocess_remove_emojis,
+        ],
+    )
     tts.write_to_fp(audio_fp)
     return base64.b64encode(audio_fp.getvalue()).decode("utf-8")
+
+
+def preprocess_default_list() -> list[Callable]:
+    return [
+        pre_processors.tone_marks,
+        pre_processors.end_of_line,
+        pre_processors.abbreviations,
+        pre_processors.word_sub,
+    ]
+
+
+def preprocess_remove_asterisk(text: str) -> str:
+    return text.replace("*", "")
+
+
+def preprocess_remove_emojis(text: str) -> str:
+    return text.encode("ascii", "ignore").decode("ascii")

--- a/tests/rpi_ai/models/test_audiobot.py
+++ b/tests/rpi_ai/models/test_audiobot.py
@@ -4,7 +4,13 @@ from unittest.mock import MagicMock
 
 from google.genai.types import Part
 
-from rpi_ai.models.audiobot import get_audio_bytes_from_text, get_audio_request
+from rpi_ai.models.audiobot import (
+    get_audio_bytes_from_text,
+    get_audio_request,
+    preprocess_default_list,
+    preprocess_remove_asterisk,
+    preprocess_remove_emojis,
+)
 
 
 def test_get_audio_request() -> None:
@@ -31,5 +37,28 @@ def test_get_audio_bytes_from_text(mock_gtts: MagicMock) -> None:
     result = get_audio_bytes_from_text(text)
     expected_result = base64.b64encode(b"test_audio_bytes").decode("utf-8")
     assert result == expected_result
-    mock_gtts.assert_called_once_with(text, lang="en", tld="co.uk")
+    mock_gtts.assert_called_once_with(
+        text,
+        lang="en",
+        tld="co.uk",
+        pre_processor_funcs=[
+            *preprocess_default_list(),
+            preprocess_remove_asterisk,
+            preprocess_remove_emojis,
+        ],
+    )
     mock_gtts_instance.write_to_fp.assert_called_once()
+
+
+def test_preprocess_remove_asterisk() -> None:
+    text = "Hello *world*!"
+    expected_result = "Hello world!"
+    result = preprocess_remove_asterisk(text)
+    assert result == expected_result
+
+
+def test_preprocess_remove_emojis() -> None:
+    text = "Hello 🌍!"
+    expected_result = "Hello !"
+    result = preprocess_remove_emojis(text)
+    assert result == expected_result


### PR DESCRIPTION
This pull request introduces enhancements to the `audiobot` module by adding text preprocessing functions to improve the quality of text-to-speech conversion. It also includes corresponding updates to the test suite to ensure these changes are properly tested.

Enhancements to text preprocessing:

* [`src/rpi_ai/models/audiobot.py`](diffhunk://#diff-2b7a4fffaa4afea1a8fc78dbebf35821b9631f3c02f5e22b34adbcb5c8a2fdc0L18-R48): Added new text preprocessing functions `preprocess_default_list`, `preprocess_remove_asterisk`, and `preprocess_remove_emojis` to improve text-to-speech conversion. These functions are integrated into the `gTTS` initialization in `get_audio_bytes_from_text`.
* [`src/rpi_ai/models/audiobot.py`](diffhunk://#diff-2b7a4fffaa4afea1a8fc78dbebf35821b9631f3c02f5e22b34adbcb5c8a2fdc0R2-R7): Imported `Callable` from `collections.abc` and `pre_processors` from `gtts.tokenizer` to support the new preprocessing functions.

Updates to test suite:

* [`tests/rpi_ai/models/test_audiobot.py`](diffhunk://#diff-fcc48fb5b04cad784c26d84cda702160dac42ce4db0244dad3128274e0c8e38aL34-R64): Updated the test for `get_audio_bytes_from_text` to include assertions for the new preprocessing functions.
* [`tests/rpi_ai/models/test_audiobot.py`](diffhunk://#diff-fcc48fb5b04cad784c26d84cda702160dac42ce4db0244dad3128274e0c8e38aL34-R64): Added new tests for `preprocess_remove_asterisk` and `preprocess_remove_emojis` to ensure they work as expected.
* [`tests/rpi_ai/models/test_audiobot.py`](diffhunk://#diff-fcc48fb5b04cad784c26d84cda702160dac42ce4db0244dad3128274e0c8e38aL7-R13): Imported the new preprocessing functions to facilitate testing.