### PR TITLE
Add TextFormatHelper for improved message formatting in MessageContainer

### DIFF
--- a/ui/lib/components/messages/message_container.dart
+++ b/ui/lib/components/messages/message_container.dart
@@ -2,6 +2,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+// Project imports:
+import 'package:ui/helpers/text_format_helper.dart';
+
 class MessageContainer extends StatelessWidget {
   final String message;
   final bool isUserMessage;
@@ -63,64 +66,6 @@ class MessageBox extends StatelessWidget {
     required this.textColour,
   }) : super(key: key);
 
-  List<TextSpan> _getFormattedText(String text, Color textColour) {
-    final RegExp boldExp = RegExp(r'\*\*(.*?)\*\*');
-    final RegExp bulletExp = RegExp(r'^\* (.*)', multiLine: true);
-    final List<TextSpan> spans = [];
-    int start = 0;
-
-    for (final Match match in bulletExp.allMatches(text)) {
-      if (match.start > start) {
-        spans.add(TextSpan(
-          text: text.substring(start, match.start),
-          style: TextStyle(color: textColour),
-        ));
-      }
-      spans.add(TextSpan(
-        text: '- ${match.group(1)}',
-        style: TextStyle(color: textColour),
-      ));
-      start = match.end;
-    }
-
-    if (start < text.length) {
-      spans.add(TextSpan(
-        text: text.substring(start),
-        style: TextStyle(color: textColour),
-      ));
-    }
-
-    final List<TextSpan> finalSpans = [];
-    for (final span in spans) {
-      final text = span.text!;
-      int boldStart = 0;
-      for (final Match match in boldExp.allMatches(text)) {
-        if (match.start > boldStart) {
-          finalSpans.add(TextSpan(
-            text: text.substring(boldStart, match.start),
-            style: span.style,
-          ));
-        }
-        finalSpans.add(TextSpan(
-          text: match.group(1),
-          style: span.style?.copyWith(
-            fontWeight: FontWeight.bold,
-            fontSize: 16,
-          ),
-        ));
-        boldStart = match.end;
-      }
-      if (boldStart < text.length) {
-        finalSpans.add(TextSpan(
-          text: text.substring(boldStart),
-          style: span.style?.copyWith(fontSize: 16),
-        ));
-      }
-    }
-
-    return finalSpans;
-  }
-
   @override
   Widget build(BuildContext context) {
     final maxWidth = MediaQuery.of(context).size.width * 0.75;
@@ -134,7 +79,8 @@ class MessageBox extends StatelessWidget {
       ),
       child: RichText(
         text: TextSpan(
-          children: _getFormattedText(message, textColour),
+          children: TextFormatHelper.formatText(
+              message, TextStyle(color: textColour)),
           style: const TextStyle(fontSize: 16),
         ),
       ),

--- a/ui/lib/helpers/text_format_helper.dart
+++ b/ui/lib/helpers/text_format_helper.dart
@@ -1,0 +1,153 @@
+// Flutter imports:
+import 'package:flutter/material.dart';
+
+class TextFormatHelper {
+  TextFormatHelper() : super();
+
+  static List<TextSpan> createBulletPoints(String text, TextStyle? style) {
+    final RegExp bulletExp = RegExp(r'^\* (.*)', multiLine: true);
+    final List<TextSpan> spans = [];
+    int start = 0;
+
+    for (final Match match in bulletExp.allMatches(text)) {
+      if (match.start > start) {
+        spans.add(TextSpan(
+          text: text.substring(start, match.start),
+          style: style,
+        ));
+      }
+      spans.add(TextSpan(
+        text: '- ${match.group(1)}',
+        style: style,
+      ));
+      start = match.end;
+    }
+
+    if (start < text.length) {
+      spans.add(TextSpan(
+        text: text.substring(start),
+        style: style,
+      ));
+    }
+
+    return spans;
+  }
+
+  static List<TextSpan> createBoldItalicText(String text, TextStyle? style) {
+    final RegExp boldItalicExp = RegExp(r'\*\*\*(.*?)\*\*\*');
+    final List<TextSpan> spans = [];
+    int start = 0;
+
+    for (final Match match in boldItalicExp.allMatches(text)) {
+      if (match.start > start) {
+        spans.add(TextSpan(
+          text: text.substring(start, match.start),
+          style: style,
+        ));
+      }
+      spans.add(TextSpan(
+        text: match.group(1),
+        style: style?.copyWith(
+          fontWeight: FontWeight.bold,
+          fontStyle: FontStyle.italic,
+          fontSize: 16,
+        ),
+      ));
+      start = match.end;
+    }
+
+    if (start < text.length) {
+      spans.add(TextSpan(
+        text: text.substring(start),
+        style: style?.copyWith(fontSize: 16),
+      ));
+    }
+
+    return spans;
+  }
+
+  static List<TextSpan> createBoldText(String text, TextStyle? style) {
+    final RegExp boldExp = RegExp(r'\*\*(.*?)\*\*');
+    final List<TextSpan> spans = [];
+    int start = 0;
+
+    for (final Match match in boldExp.allMatches(text)) {
+      if (match.start > start) {
+        spans.add(TextSpan(
+          text: text.substring(start, match.start),
+          style: style,
+        ));
+      }
+      spans.add(TextSpan(
+        text: match.group(1),
+        style: style?.copyWith(
+          fontWeight: FontWeight.bold,
+          fontSize: 16,
+        ),
+      ));
+      start = match.end;
+    }
+
+    if (start < text.length) {
+      spans.add(TextSpan(
+        text: text.substring(start),
+        style: style?.copyWith(fontSize: 16),
+      ));
+    }
+
+    return spans;
+  }
+
+  static List<TextSpan> createItalicText(String text, TextStyle? style) {
+    final RegExp italicExp = RegExp(r'\*(.*?)\*');
+    final List<TextSpan> spans = [];
+    int start = 0;
+
+    for (final Match match in italicExp.allMatches(text)) {
+      if (match.start > start) {
+        spans.add(TextSpan(
+          text: text.substring(start, match.start),
+          style: style,
+        ));
+      }
+      spans.add(TextSpan(
+        text: match.group(1),
+        style: style?.copyWith(
+          fontStyle: FontStyle.italic,
+          fontSize: 16,
+        ),
+      ));
+      start = match.end;
+    }
+
+    if (start < text.length) {
+      spans.add(TextSpan(
+        text: text.substring(start),
+        style: style?.copyWith(fontSize: 16),
+      ));
+    }
+
+    return spans;
+  }
+
+  static List<TextSpan> formatText(String text, TextStyle? style) {
+    final List<TextSpan> bulletSpans = createBulletPoints(text, style);
+    final List<TextSpan> finalSpans = [];
+
+    for (final span in bulletSpans) {
+      finalSpans.addAll(createBoldItalicText(span.text!, span.style));
+    }
+
+    final List<TextSpan> boldSpans = [];
+    for (final span in finalSpans) {
+      boldSpans.addAll(createBoldText(span.text!, span.style));
+    }
+
+    final List<TextSpan> italicSpans = [];
+    for (final span in boldSpans) {
+      italicSpans.addAll(createItalicText(span.text!, span.style));
+    }
+
+    return italicSpans;
+  }
+}

--- a/ui/lib/helpers/text_format_helper.dart
+++ b/ui/lib/helpers/text_format_helper.dart
@@ -2,8 +2,6 @@
 import 'package:flutter/material.dart';
 
 class TextFormatHelper {
-  TextFormatHelper() : super();
-
   static List<TextSpan> createBulletPoints(String text, TextStyle? style) {
     final RegExp bulletExp = RegExp(r'^\* (.*)', multiLine: true);
     final List<TextSpan> spans = [];

--- a/ui/test/components/messages/message_container_test.dart
+++ b/ui/test/components/messages/message_container_test.dart
@@ -85,12 +85,13 @@ void main() {
     expect(find.text('Copied to clipboard'), findsOneWidget);
   });
 
-  testWidgets('MessageContainer displays bold text correctly',
+  testWidgets('MessageContainer displays formatted text correctly',
       (WidgetTester tester) async {
     final timestamp = DateTime(2023, 10, 1, 14, 30);
     await tester.pumpWidget(
       createMessageContainer(
-        message: 'This is **bold** text',
+        message:
+            'This is **bold** text\n* Bullet point 1\n* Bullet point 2\nThis is ***bold and italic*** text',
         isUserMessage: true,
         timestamp: timestamp,
       ),
@@ -105,47 +106,7 @@ void main() {
     final RichText richTextWidget = tester.widget<RichText>(richTextFinder);
     final TextSpan textSpan = richTextWidget.text as TextSpan;
 
-    expect(textSpan.children, isNotNull);
-    expect(textSpan.children!.length, 3);
-
-    final TextSpan normalTextSpan1 = textSpan.children![0] as TextSpan;
-    final TextSpan boldTextSpan = textSpan.children![1] as TextSpan;
-    final TextSpan normalTextSpan2 = textSpan.children![2] as TextSpan;
-
-    expect(normalTextSpan1.text, 'This is ');
-    expect(normalTextSpan1.style?.fontWeight, null);
-    expect(boldTextSpan.text, 'bold');
-    expect(boldTextSpan.style?.fontWeight, FontWeight.bold);
-    expect(normalTextSpan2.text, ' text');
-    expect(normalTextSpan2.style?.fontWeight, null);
-  });
-
-  testWidgets('MessageContainer displays bullet points correctly',
-      (WidgetTester tester) async {
-    final timestamp = DateTime(2023, 10, 1, 14, 30);
-    await tester.pumpWidget(
-      createMessageContainer(
-        message: '* Bullet point 1\n* Bullet point 2',
-        isUserMessage: true,
-        timestamp: timestamp,
-      ),
-    );
-
-    final richTextFinder = find.descendant(
-      of: find.byType(MessageBox),
-      matching: find.byType(RichText),
-    );
-    expect(richTextFinder, findsOneWidget);
-
-    final RichText richTextWidget = tester.widget<RichText>(richTextFinder);
-    final TextSpan textSpan = richTextWidget.text as TextSpan;
-
-    expect(textSpan.children, isNotNull);
-
-    final TextSpan bulletPoint1 = textSpan.children![0] as TextSpan;
-    final TextSpan bulletPoint2 = textSpan.children![2] as TextSpan;
-
-    expect(bulletPoint1.text, '- Bullet point 1');
-    expect(bulletPoint2.text, '- Bullet point 2');
+    expect(textSpan.toPlainText(),
+        'This is bold text\n- Bullet point 1\n- Bullet point 2\nThis is bold and italic text');
   });
 }

--- a/ui/test/helpers/text_format_helper_test.dart
+++ b/ui/test/helpers/text_format_helper_test.dart
@@ -1,0 +1,75 @@
+// Flutter imports:
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
+import 'package:ui/helpers/text_format_helper.dart';
+
+void main() {
+  test('createBoldText formats bold text correctly', () {
+    const text = 'This is **bold** text';
+    final spans = TextFormatHelper.createBoldText(text, const TextStyle());
+
+    expect(spans.length, 3);
+    expect(spans[0].text, 'This is ');
+    expect(spans[1].text, 'bold');
+    expect(spans[1].style?.fontWeight, FontWeight.bold);
+    expect(spans[2].text, ' text');
+  });
+
+  test('createItalicText formats italic text correctly', () {
+    const text = 'This is *italic* text';
+    final spans = TextFormatHelper.createItalicText(text, const TextStyle());
+
+    expect(spans.length, 3);
+    expect(spans[0].text, 'This is ');
+    expect(spans[1].text, 'italic');
+    expect(spans[1].style?.fontStyle, FontStyle.italic);
+    expect(spans[2].text, ' text');
+  });
+
+  test('createBoldItalicText formats bold and italic text correctly', () {
+    const text = 'This is ***bold and italic*** text';
+    final spans =
+        TextFormatHelper.createBoldItalicText(text, const TextStyle());
+
+    expect(spans.length, 3);
+    expect(spans[0].text, 'This is ');
+    expect(spans[1].text, 'bold and italic');
+    expect(spans[1].style?.fontWeight, FontWeight.bold);
+    expect(spans[1].style?.fontStyle, FontStyle.italic);
+    expect(spans[2].text, ' text');
+  });
+
+  test('createBulletPoints formats bullet points correctly', () {
+    const text = '* Bullet point 1\n* Bullet point 2';
+    final spans = TextFormatHelper.createBulletPoints(text, const TextStyle());
+
+    expect(spans.length, 3);
+    expect(spans[0].text, '- Bullet point 1');
+    expect(spans[1].text, '\n');
+    expect(spans[2].text, '- Bullet point 2');
+  });
+
+  test('formatText applies all formatting correctly', () {
+    const text =
+        '*   **Item 1 - Bold item**\n*   *Item 2 - Italicized item*\n*   ***Item 3 - Bold and italicized item***';
+    final spans = TextFormatHelper.formatText(text, const TextStyle());
+
+    expect(spans.length, 8);
+    expect(spans[0].text, '-   ');
+    expect(spans[1].text, 'Item 1 - Bold item');
+    expect(spans[1].style?.fontWeight, FontWeight.bold);
+    expect(spans[2].text, '\n');
+    expect(spans[3].text, '-   ');
+    expect(spans[4].text, 'Item 2 - Italicized item');
+    expect(spans[4].style?.fontStyle, FontStyle.italic);
+    expect(spans[5].text, '\n');
+    expect(spans[6].text, '-   ');
+    expect(spans[7].text, 'Item 3 - Bold and italicized item');
+    expect(spans[7].style?.fontWeight, FontWeight.bold);
+    expect(spans[7].style?.fontStyle, FontStyle.italic);
+  });
+}


### PR DESCRIPTION
This pull request refactors the text formatting logic in the `MessageContainer` component by moving the formatting functions into a new helper class, `TextFormatHelper`. It also updates the related tests to ensure all text formatting is correctly applied.

### Refactoring of text formatting logic:

* [`ui/lib/components/messages/message_container.dart`](diffhunk://#diff-29fb457b1a8ce362e0248b3b29cdb0e8141d6128dc3c886f9f9ae93767718becL66-L123): Removed the `_getFormattedText` method and replaced its usage with `TextFormatHelper.formatText` to handle text formatting. [[1]](diffhunk://#diff-29fb457b1a8ce362e0248b3b29cdb0e8141d6128dc3c886f9f9ae93767718becL66-L123) [[2]](diffhunk://#diff-29fb457b1a8ce362e0248b3b29cdb0e8141d6128dc3c886f9f9ae93767718becL137-R83)
* [`ui/lib/helpers/text_format_helper.dart`](diffhunk://#diff-b18bd6503821e1c5f2739a000373c30bd457714c79b489c73ad0ae503a715a5aR1-R153): Added a new helper class `TextFormatHelper` that includes methods for creating bullet points, bold, italic, and bold-italic text spans, and a `formatText` method that applies all these formats.

### Test updates:

* [`ui/test/components/messages/message_container_test.dart`](diffhunk://#diff-2acb2e1d487388d36aa40c610d87db189ab3d8f8c218f082fff49a58ad7f191aL88-R94): Updated the widget test to cover all text formatting scenarios, including bold, bullet points, and bold-italic text. [[1]](diffhunk://#diff-2acb2e1d487388d36aa40c610d87db189ab3d8f8c218f082fff49a58ad7f191aL88-R94) [[2]](diffhunk://#diff-2acb2e1d487388d36aa40c610d87db189ab3d8f8c218f082fff49a58ad7f191aL108-R110)
* [`ui/test/helpers/text_format_helper_test.dart`](diffhunk://#diff-c639896e12ba45cf8c279cb99ef03641f11b514238643deb377d39b27fce3f74R1-R75): Added new unit tests for the `TextFormatHelper` class to ensure each formatting method works correctly.