### PR TITLE
Add message history

### DIFF
--- a/tests/rpi_ai/conftest.py
+++ b/tests/rpi_ai/conftest.py
@@ -61,7 +61,8 @@ def mock_genai_client() -> Generator[MagicMock, None, None]:
 def mock_chat_instance(mock_genai_client: MagicMock) -> MagicMock:
     mock_instance = MagicMock()
     mock_genai_client.return_value.chats.create.return_value = mock_instance
-    mock_instance.send_message.return_value = MagicMock(parts=[MagicMock(text="What's on your mind today?")])
+    mock_instance._curated_history = [MagicMock(parts=[MagicMock(text="What's on your mind today?")], role="model")]
+    mock_instance.send_message.return_value = MagicMock(parts=[MagicMock(text="Hi user!")])
     return mock_instance
 
 
@@ -80,6 +81,12 @@ def mock_get_config(mock_config: AIConfigType) -> Generator[MagicMock, None, Non
 @pytest.fixture
 def mock_update_config() -> Generator[MagicMock, None, None]:
     with patch("rpi_ai.main.Chatbot.update_config") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_get_chat_history() -> Generator[MagicMock, None, None]:
+    with patch("rpi_ai.main.Chatbot.get_chat_history") as mock:
         yield mock
 
 

--- a/tests/rpi_ai/test_api_types.py
+++ b/tests/rpi_ai/test_api_types.py
@@ -1,7 +1,9 @@
 import json
 from unittest.mock import mock_open, patch
 
-from rpi_ai.api_types import AIConfigType, Message, SpeechResponse
+from google.genai.types import Content, Part
+
+from rpi_ai.api_types import AIConfigType, MessageList, SpeechResponse
 
 
 # Config
@@ -25,18 +27,31 @@ class TestAIConfigType:
 
 
 # Chatbot responses
-class TestMessage:
-    def test_from_dict_user_message(self) -> None:
-        data = {"role": "user", "parts": "Hello, world!"}
-        message = Message.from_dict(data)
-        assert message.message == "Hello, world!"
-        assert message.is_user_message
+class TestMessageList:
+    def test_from_contents_list(self) -> None:
+        data = [
+            Content(parts=[Part(text="user_msg")], role="user"),
+            Content(parts=[Part(text="model_msg")], role="model"),
+        ]
+        message_list = MessageList.from_contents_list(data)
+        assert len(message_list.messages) == len(data)
+        assert message_list.messages[0].message == "user_msg"
+        assert message_list.messages[0].is_user_message
+        assert message_list.messages[1].message == "model_msg"
+        assert not message_list.messages[1].is_user_message
 
-    def test_from_dict_model_message(self) -> None:
-        data = {"role": "model", "parts": "Hello, user!"}
-        message = Message.from_dict(data)
-        assert message.message == "Hello, user!"
-        assert not message.is_user_message
+    def test_history(self) -> None:
+        data = [
+            Content(parts=[Part(text="user_msg")], role="user"),
+            Content(parts=[Part(text="model_msg")], role="model"),
+        ]
+        message_list = MessageList.from_contents_list(data)
+        history = message_list.history
+        assert len(history) == len(data)
+        assert history[0].parts[0].text == "user_msg"
+        assert history[0].role == "user"
+        assert history[1].parts[0].text == "model_msg"
+        assert history[1].role == "model"
 
 
 class TestSpeechResponse:

--- a/tests/rpi_ai/test_main.py
+++ b/tests/rpi_ai/test_main.py
@@ -106,14 +106,14 @@ class TestAIAppEndpoints:
         self,
         mock_client: FlaskClient,
         mock_request_headers: MagicMock,
-        mock_start_chat: MagicMock,
+        mock_get_chat_history: MagicMock,
         mock_jsonify: MagicMock,
         mock_create_new_token: MagicMock,
     ) -> None:
         mock_request_headers.return_value = {"Authorization": mock_create_new_token.return_value}
         response = mock_client.get("/login")
-        mock_start_chat.assert_called_once()
-        mock_jsonify.assert_called_once_with(mock_start_chat.return_value)
+        mock_get_chat_history.assert_called_once()
+        mock_jsonify.assert_called_once_with(mock_get_chat_history.return_value)
         assert response.status_code == SUCCESS_CODE
 
     def test_login_unauthorized(
@@ -158,6 +158,7 @@ class TestAIAppEndpoints:
         mock_request_json: MagicMock,
         mock_update_config: MagicMock,
         mock_save_config: MagicMock,
+        mock_get_chat_history: MagicMock,
         mock_start_chat: MagicMock,
         mock_jsonify: MagicMock,
         mock_create_new_token: MagicMock,
@@ -176,7 +177,8 @@ class TestAIAppEndpoints:
         mock_update_config.assert_called_once_with(AIConfigType(**new_config))
         mock_save_config.assert_called_once()
         mock_start_chat.assert_called_once()
-        mock_jsonify.assert_called_once_with(mock_start_chat.return_value)
+        mock_get_chat_history.assert_called_once()
+        mock_jsonify.assert_called_once_with(mock_get_chat_history.return_value)
         assert response.status_code == SUCCESS_CODE
 
     def test_update_config_unauthorized(
@@ -197,6 +199,33 @@ class TestAIAppEndpoints:
         mock_request_json.return_value = new_config
 
         response = mock_client.post("/update-config")
+        mock_jsonify.assert_called_once_with({"error": "Unauthorized"})
+        assert response.status_code == UNAUTHORIZED_CODE
+
+    def test_restart_chat(
+        self,
+        mock_client: FlaskClient,
+        mock_request_headers: MagicMock,
+        mock_get_chat_history: MagicMock,
+        mock_start_chat: MagicMock,
+        mock_jsonify: MagicMock,
+        mock_create_new_token: MagicMock,
+    ) -> None:
+        mock_request_headers.return_value = {"Authorization": mock_create_new_token.return_value}
+        response = mock_client.post("/restart-chat")
+        mock_start_chat.assert_called_once()
+        mock_get_chat_history.assert_called_once()
+        mock_jsonify.assert_called_once_with(mock_get_chat_history.return_value)
+        assert response.status_code == SUCCESS_CODE
+
+    def test_restart_chat_unauthorized(
+        self,
+        mock_client: FlaskClient,
+        mock_request_headers: MagicMock,
+        mock_jsonify: MagicMock,
+    ) -> None:
+        mock_request_headers.return_value = {"Authorization": "wrong_token"}
+        response = mock_client.post("/restart-chat")
         mock_jsonify.assert_called_once_with({"error": "Unauthorized"})
         assert response.status_code == UNAUTHORIZED_CODE
 

--- a/ui/lib/components/app_bar/settings_dialog.dart
+++ b/ui/lib/components/app_bar/settings_dialog.dart
@@ -60,7 +60,7 @@ class SettingsDialog extends StatelessWidget {
           try {
             httpHelper
                 .updateConfig(appState.fullUrl, appState.authToken, config)
-                .then((value) {
+                .then((messages) {
               settingsState.updateConfig({
                 'model': config['model'],
                 'systemInstruction': config['system_instruction'],
@@ -68,7 +68,7 @@ class SettingsDialog extends StatelessWidget {
                 'maxOutputTokens': config['max_output_tokens'],
                 'temperature': config['temperature'],
               });
-              messageState.initialiseChat(value);
+              messageState.initialiseChat(messages);
             });
           } catch (error) {
             notificationState

--- a/ui/lib/components/app_bar/settings_dialog.dart
+++ b/ui/lib/components/app_bar/settings_dialog.dart
@@ -45,6 +45,26 @@ class SettingsDialog extends StatelessWidget {
       );
     }
 
+    Widget restartChatButton() {
+      return TextButton(
+        child: const Text('Restart Chat'),
+        onPressed: () {
+          try {
+            httpHelper
+                .postRestartChat(appState.fullUrl, appState.authToken)
+                .then((messages) {
+              messageState.initialiseChat(messages);
+            });
+          } catch (error) {
+            notificationState
+                .setNotificationError('Error updating settings: $error');
+          }
+
+          Navigator.of(context).pop();
+        },
+      );
+    }
+
     Widget updateButton() {
       return TextButton(
         child: const Text('Update'),
@@ -135,6 +155,7 @@ class SettingsDialog extends StatelessWidget {
       ),
       actions: <Widget>[
         closeButton(),
+        restartChatButton(),
         updateButton(),
       ],
     );

--- a/ui/lib/helpers/http_helper.dart
+++ b/ui/lib/helpers/http_helper.dart
@@ -42,7 +42,7 @@ class HttpHelper {
     }
   }
 
-  Future<Map<String, dynamic>> getLoginResponse(
+  Future<List<Map<String, dynamic>>> getLoginResponse(
       String url, String authToken) async {
     final headers = <String, String>{
       'Authorization': authToken,
@@ -51,11 +51,14 @@ class HttpHelper {
 
     if (response.statusCode == 200) {
       final Map<String, dynamic> body = jsonDecode(response.body);
-      return {
-        'text': body['message'].toString().trim(),
-        'isUserMessage': body['is_user_message'],
-        'timestamp': DateTime.now(),
-      };
+      final List<dynamic> messages = body['messages'];
+      return messages.map((message) {
+        return {
+          'text': message['message'].toString().trim(),
+          'isUserMessage': message['is_user_message'],
+          'timestamp': DateTime.now(),
+        };
+      }).toList();
     }
 
     // Raise exception if response status code is not 200
@@ -84,7 +87,7 @@ class HttpHelper {
         'Getting config failed: (${response.statusCode}) ${response.body}');
   }
 
-  Future<Map<String, dynamic>> updateConfig(
+  Future<List<Map<String, dynamic>>> updateConfig(
       String url, String authToken, Map<String, dynamic> config) async {
     final headers = <String, String>{
       'Authorization': authToken,
@@ -96,16 +99,42 @@ class HttpHelper {
 
     if (response.statusCode == 200) {
       final Map<String, dynamic> body = jsonDecode(response.body);
-      return {
-        'text': body['message'].toString().trim(),
-        'isUserMessage': body['is_user_message'],
-        'timestamp': DateTime.now(),
-      };
+      final List<dynamic> messages = body['messages'];
+      return messages.map((message) {
+        return {
+          'text': message['message'].toString().trim(),
+          'isUserMessage': message['is_user_message'],
+          'timestamp': DateTime.now(),
+        };
+      }).toList();
     }
 
     // Raise exception if response status code is not 200
     throw Exception(
         'Updating config failed: (${response.statusCode}) ${response.body}');
+  }
+
+  Future<List<Map<String, dynamic>>> postRestartChat(
+      String url, String authToken) async {
+    final headers = <String, String>{
+      'Authorization': authToken,
+    };
+    final response = await getResponseFromUri('$url/restart-chat', headers);
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> body = jsonDecode(response.body);
+      final List<dynamic> messages = body['messages'];
+      return messages.map((message) {
+        return {
+          'text': message['message'].toString().trim(),
+          'isUserMessage': message['is_user_message'],
+          'timestamp': DateTime.now(),
+        };
+      }).toList();
+    }
+
+    // Raise exception if response status code is not 200
+    throw Exception('Login failed: (${response.statusCode}) ${response.body}');
   }
 
   Future<Map<String, dynamic>> chat(

--- a/ui/lib/helpers/http_helper.dart
+++ b/ui/lib/helpers/http_helper.dart
@@ -119,7 +119,7 @@ class HttpHelper {
     final headers = <String, String>{
       'Authorization': authToken,
     };
-    final response = await getResponseFromUri('$url/restart-chat', headers);
+    final response = await postResponseToUri('$url/restart-chat', headers, '');
 
     if (response.statusCode == 200) {
       final Map<String, dynamic> body = jsonDecode(response.body);
@@ -134,7 +134,8 @@ class HttpHelper {
     }
 
     // Raise exception if response status code is not 200
-    throw Exception('Login failed: (${response.statusCode}) ${response.body}');
+    throw Exception(
+        'Restarting chat failed: (${response.statusCode}) ${response.body}');
   }
 
   Future<Map<String, dynamic>> chat(

--- a/ui/lib/pages/login_page.dart
+++ b/ui/lib/pages/login_page.dart
@@ -97,15 +97,15 @@ class _LoginPageState extends State<LoginPage> {
         child: const Text('Connect'),
         onPressed: () async {
           try {
-            final Map<String, dynamic> message = await httpHelper
+            final List<Map<String, dynamic>> messages = await httpHelper
                 .getLoginResponse(appState.fullUrl, appState.authToken);
             final Map<String, dynamic> config = await httpHelper.getConfig(
                 appState.fullUrl, appState.authToken);
 
-            if (message.isNotEmpty) {
+            if (messages.isNotEmpty) {
               settingsState.updateConfig(config);
               appState.setConnected(true);
-              messageState.initialiseChat(message);
+              messageState.initialiseChat(messages);
               appState.setActivePage(PageType.text);
               notificationState.clearNotification();
             }

--- a/ui/lib/state/message_state.dart
+++ b/ui/lib/state/message_state.dart
@@ -11,6 +11,11 @@ class MessageState extends ChangeNotifier {
     notifyListeners();
   }
 
+  void addMessages(List<Map<String, dynamic>> messages) {
+    _messages.addAll(messages);
+    notifyListeners();
+  }
+
   void clearMessages() {
     _messages.clear();
     notifyListeners();
@@ -23,8 +28,8 @@ class MessageState extends ChangeNotifier {
     }
   }
 
-  void initialiseChat(Map<String, dynamic> message) {
+  void initialiseChat(List<Map<String, dynamic>> messages) {
     clearMessages();
-    addMessage(message);
+    addMessages(messages);
   }
 }

--- a/ui/test/components/app_bar/settings_dialog_test.dart
+++ b/ui/test/components/app_bar/settings_dialog_test.dart
@@ -172,6 +172,30 @@ void main() {
 
     expect(find.byType(AlertDialog), findsNothing);
   });
+
+  testWidgets(
+      'SettingsDialog shows error notification when Restart chat button is pressed and an error occurs',
+      (WidgetTester tester) async {
+    when(mockHttpHelper.postRestartChat(any, any))
+        .thenThrow(Exception('Failed to restart chat'));
+
+    await tester.pumpWidget(createSettingsDialog());
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('Restart Chat'));
+    await tester.pumpAndSettle();
+
+    final notificationState = Provider.of<NotificationState>(
+        tester.element(find.byType(MaterialApp)),
+        listen: false);
+    expect(notificationState.notificationState, NotificationType.error);
+    expect(notificationState.notificationMessage,
+        'Error updating settings: Exception: Failed to restart chat');
+
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
   testWidgets('SettingsDialog closes when Close button is pressed',
       (WidgetTester tester) async {
     await tester.pumpWidget(createSettingsDialog());

--- a/ui/test/components/app_bar/settings_dialog_test.dart
+++ b/ui/test/components/app_bar/settings_dialog_test.dart
@@ -85,11 +85,9 @@ void main() {
   testWidgets(
       'SettingsDialog updates SettingsState when Update button is pressed',
       (WidgetTester tester) async {
-    when(mockHttpHelper.updateConfig(any, any, any)).thenAnswer((_) async => {
-          'text': 'Config updated successfully',
-          'isUserMessage': false,
-          'timestamp': DateTime.now(),
-        });
+    when(mockHttpHelper.updateConfig(any, any, any)).thenAnswer((_) async => [
+          {'text': 'Config updated successfully', 'isUserMessage': false},
+        ]);
 
     await tester.pumpWidget(createSettingsDialog());
 
@@ -108,11 +106,19 @@ void main() {
     final settingsState = Provider.of<SettingsState>(
         tester.element(find.byType(MaterialApp)),
         listen: false);
+    final messageState = Provider.of<MessageState>(
+        tester.element(find.byType(MaterialApp)),
+        listen: false);
     expect(settingsState.model, 'newModel');
     expect(settingsState.systemInstruction, 'newSystemInstruction');
     expect(settingsState.candidateCount, 5);
     expect(settingsState.maxOutputTokens, 1500);
     expect(settingsState.temperature, 1.5);
+    expect(messageState.messages.length, 1);
+    expect(
+      messageState.messages[0],
+      {'text': 'Config updated successfully', 'isUserMessage': false},
+    );
 
     expect(find.byType(AlertDialog), findsNothing);
   });

--- a/ui/test/components/app_bar/settings_dialog_test.dart
+++ b/ui/test/components/app_bar/settings_dialog_test.dart
@@ -146,6 +146,32 @@ void main() {
     expect(find.byType(AlertDialog), findsNothing);
   });
 
+  testWidgets(
+      'SettingsDialog restarts chat when Restart Chat button is pressed',
+      (WidgetTester tester) async {
+    when(mockHttpHelper.postRestartChat(any, any)).thenAnswer((_) async => [
+          {'text': 'Chat restarted', 'is_user_message': false},
+          {'text': 'Welcome back', 'is_user_message': true}
+        ]);
+
+    await tester.pumpWidget(createSettingsDialog());
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('Restart Chat'));
+    await tester.pumpAndSettle();
+
+    final messageState = Provider.of<MessageState>(
+        tester.element(find.byType(MaterialApp)),
+        listen: false);
+    expect(messageState.messages.length, 2);
+    expect(messageState.messages[0],
+        {'text': 'Chat restarted', 'is_user_message': false});
+    expect(messageState.messages[1],
+        {'text': 'Welcome back', 'is_user_message': true});
+
+    expect(find.byType(AlertDialog), findsNothing);
+  });
   testWidgets('SettingsDialog closes when Close button is pressed',
       (WidgetTester tester) async {
     await tester.pumpWidget(createSettingsDialog());

--- a/ui/test/components/app_bar/settings_dialog_test.mocks.dart
+++ b/ui/test/components/app_bar/settings_dialog_test.mocks.dart
@@ -128,7 +128,7 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<bool>);
 
   @override
-  _i4.Future<Map<String, dynamic>> getLoginResponse(
+  _i4.Future<List<Map<String, dynamic>>> getLoginResponse(
     String? url,
     String? authToken,
   ) =>
@@ -140,9 +140,26 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             authToken,
           ],
         ),
-        returnValue:
-            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i4.Future<Map<String, dynamic>>);
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
+
+  @override
+  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
+    String? url,
+    String? authToken,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postRestartChat,
+          [
+            url,
+            authToken,
+          ],
+        ),
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
   _i4.Future<Map<String, dynamic>> getConfig(
@@ -162,7 +179,7 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
-  _i4.Future<Map<String, dynamic>> updateConfig(
+  _i4.Future<List<Map<String, dynamic>>> updateConfig(
     String? url,
     String? authToken,
     Map<String, dynamic>? config,
@@ -176,9 +193,9 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             config,
           ],
         ),
-        returnValue:
-            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i4.Future<Map<String, dynamic>>);
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
   _i4.Future<Map<String, dynamic>> chat(

--- a/ui/test/components/app_bar/settings_dialog_test.mocks.dart
+++ b/ui/test/components/app_bar/settings_dialog_test.mocks.dart
@@ -145,23 +145,6 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
-  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
-    String? url,
-    String? authToken,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #postRestartChat,
-          [
-            url,
-            authToken,
-          ],
-        ),
-        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
-            <Map<String, dynamic>>[]),
-      ) as _i4.Future<List<Map<String, dynamic>>>);
-
-  @override
   _i4.Future<Map<String, dynamic>> getConfig(
     String? url,
     String? authToken,
@@ -191,6 +174,23 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             url,
             authToken,
             config,
+          ],
+        ),
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
+
+  @override
+  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
+    String? url,
+    String? authToken,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postRestartChat,
+          [
+            url,
+            authToken,
           ],
         ),
         returnValue: _i4.Future<List<Map<String, dynamic>>>.value(

--- a/ui/test/components/conversation/text_input_test.mocks.dart
+++ b/ui/test/components/conversation/text_input_test.mocks.dart
@@ -151,23 +151,6 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
-  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
-    String? url,
-    String? authToken,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #postRestartChat,
-          [
-            url,
-            authToken,
-          ],
-        ),
-        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
-            <Map<String, dynamic>>[]),
-      ) as _i4.Future<List<Map<String, dynamic>>>);
-
-  @override
   _i4.Future<Map<String, dynamic>> getConfig(
     String? url,
     String? authToken,
@@ -197,6 +180,23 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             url,
             authToken,
             config,
+          ],
+        ),
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
+
+  @override
+  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
+    String? url,
+    String? authToken,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postRestartChat,
+          [
+            url,
+            authToken,
           ],
         ),
         returnValue: _i4.Future<List<Map<String, dynamic>>>.value(

--- a/ui/test/components/conversation/text_input_test.mocks.dart
+++ b/ui/test/components/conversation/text_input_test.mocks.dart
@@ -134,7 +134,7 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<bool>);
 
   @override
-  _i4.Future<Map<String, dynamic>> getLoginResponse(
+  _i4.Future<List<Map<String, dynamic>>> getLoginResponse(
     String? url,
     String? authToken,
   ) =>
@@ -146,9 +146,26 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             authToken,
           ],
         ),
-        returnValue:
-            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i4.Future<Map<String, dynamic>>);
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
+
+  @override
+  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
+    String? url,
+    String? authToken,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postRestartChat,
+          [
+            url,
+            authToken,
+          ],
+        ),
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
   _i4.Future<Map<String, dynamic>> getConfig(
@@ -168,7 +185,7 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
-  _i4.Future<Map<String, dynamic>> updateConfig(
+  _i4.Future<List<Map<String, dynamic>>> updateConfig(
     String? url,
     String? authToken,
     Map<String, dynamic>? config,
@@ -182,9 +199,9 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             config,
           ],
         ),
-        returnValue:
-            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i4.Future<Map<String, dynamic>>);
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
   _i4.Future<Map<String, dynamic>> chat(
@@ -420,6 +437,15 @@ class MockMessageState extends _i1.Mock implements _i10.MessageState {
       );
 
   @override
+  void addMessages(List<Map<String, dynamic>>? messages) => super.noSuchMethod(
+        Invocation.method(
+          #addMessages,
+          [messages],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   void clearMessages() => super.noSuchMethod(
         Invocation.method(
           #clearMessages,
@@ -438,10 +464,11 @@ class MockMessageState extends _i1.Mock implements _i10.MessageState {
       );
 
   @override
-  void initialiseChat(Map<String, dynamic>? message) => super.noSuchMethod(
+  void initialiseChat(List<Map<String, dynamic>>? messages) =>
+      super.noSuchMethod(
         Invocation.method(
           #initialiseChat,
-          [message],
+          [messages],
         ),
         returnValueForMissingStub: null,
       );

--- a/ui/test/helpers/http_helper_test.dart
+++ b/ui/test/helpers/http_helper_test.dart
@@ -78,7 +78,7 @@ void main() {
   });
 
   test(
-      'getLoginResponse returns a message if the http call completes successfully',
+      'getLoginResponse returns a list of messages if the http call completes successfully',
       () async {
     final httpHelper = HttpHelper(client: client);
     const uri = 'http://example.com';
@@ -88,11 +88,24 @@ void main() {
       Uri.parse('$uri/login'),
       headers: {'Authorization': authToken},
     )).thenAnswer((_) async => http.Response(
-        jsonEncode({'message': 'Welcome', 'is_user_message': true}), 200));
+        jsonEncode({
+          'messages': [
+            {'message': 'Welcome', 'is_user_message': true},
+            {'message': 'Hello', 'is_user_message': false}
+          ]
+        }),
+        200));
 
-    expect(await httpHelper.getLoginResponse(uri, authToken), {
+    final messages = await httpHelper.getLoginResponse(uri, authToken);
+    expect(messages.length, 2);
+    expect(messages[0], {
       'text': 'Welcome',
       'isUserMessage': true,
+      'timestamp': isA<DateTime>(),
+    });
+    expect(messages[1], {
+      'text': 'Hello',
+      'isUserMessage': false,
       'timestamp': isA<DateTime>(),
     });
   });
@@ -155,7 +168,7 @@ void main() {
   });
 
   test(
-      'updateConfig returns the first message if the http call completes successfully',
+      'updateConfig returns a list of messages if the http call completes successfully',
       () async {
     final httpHelper = HttpHelper(client: client);
     const uri = 'http://example.com';
@@ -177,12 +190,17 @@ void main() {
       body: jsonEncode(config),
     )).thenAnswer((_) async => http.Response(
         jsonEncode({
-          'message': 'Config updated successfully',
-          'is_user_message': false,
+          'messages': [
+            {
+              'message': 'Config updated successfully',
+              'is_user_message': false
+            },
+          ]
         }),
         200));
 
-    expect(await httpHelper.updateConfig(uri, authToken, config), {
+    final messages = await httpHelper.updateConfig(uri, authToken, config);
+    expect(messages[0], {
       'text': 'Config updated successfully',
       'isUserMessage': false,
       'timestamp': isA<DateTime>(),
@@ -213,6 +231,48 @@ void main() {
     )).thenAnswer((_) async => http.Response('Not Found', 404));
 
     expect(httpHelper.updateConfig(uri, authToken, config), throwsException);
+  });
+
+  test(
+      'postRestartChat returns a list of one message if the http call completes successfully',
+      () async {
+    final httpHelper = HttpHelper(client: client);
+    const uri = 'http://example.com';
+    const authToken = 'testToken';
+
+    when(client.get(
+      Uri.parse('$uri/restart-chat'),
+      headers: {'Authorization': authToken},
+    )).thenAnswer((_) async => http.Response(
+        jsonEncode({
+          'messages': [
+            {'message': 'Chat restarted', 'is_user_message': false},
+          ]
+        }),
+        200));
+
+    final messages = await httpHelper.postRestartChat(uri, authToken);
+    expect(messages.length, 1);
+    expect(messages[0], {
+      'text': 'Chat restarted',
+      'isUserMessage': false,
+      'timestamp': isA<DateTime>(),
+    });
+  });
+
+  test(
+      'postRestartChat throws an exception if the http call completes with an error',
+      () {
+    final httpHelper = HttpHelper(client: client);
+    const uri = 'http://example.com';
+    const authToken = 'testToken';
+
+    when(client.get(
+      Uri.parse('$uri/restart-chat'),
+      headers: {'Authorization': authToken},
+    )).thenAnswer((_) async => http.Response('Not Found', 404));
+
+    expect(httpHelper.postRestartChat(uri, authToken), throwsException);
   });
 
   test('chat returns a message if the http call completes successfully',

--- a/ui/test/helpers/http_helper_test.dart
+++ b/ui/test/helpers/http_helper_test.dart
@@ -240,9 +240,10 @@ void main() {
     const uri = 'http://example.com';
     const authToken = 'testToken';
 
-    when(client.get(
+    when(client.post(
       Uri.parse('$uri/restart-chat'),
       headers: {'Authorization': authToken},
+      body: '',
     )).thenAnswer((_) async => http.Response(
         jsonEncode({
           'messages': [
@@ -267,9 +268,10 @@ void main() {
     const uri = 'http://example.com';
     const authToken = 'testToken';
 
-    when(client.get(
+    when(client.post(
       Uri.parse('$uri/restart-chat'),
       headers: {'Authorization': authToken},
+      body: '',
     )).thenAnswer((_) async => http.Response('Not Found', 404));
 
     expect(httpHelper.postRestartChat(uri, authToken), throwsException);

--- a/ui/test/pages/login_page_test.dart
+++ b/ui/test/pages/login_page_test.dart
@@ -82,8 +82,10 @@ void main() {
 
   testWidgets('Connect button triggers login process',
       (WidgetTester tester) async {
-    when(mockHttpHelper.getLoginResponse(any, any)).thenAnswer(
-        (_) async => {'message': 'Hello', 'is_user_message': false});
+    when(mockHttpHelper.getLoginResponse(any, any)).thenAnswer((_) async => [
+          {'text': 'Hello', 'is_user_message': false},
+          {'text': 'Welcome', 'is_user_message': true}
+        ]);
     when(mockHttpHelper.getConfig(any, any)).thenAnswer((_) async => {
           'model': 'model',
           'systemInstruction': 'instruction',
@@ -109,7 +111,15 @@ void main() {
     final appState = Provider.of<AppState>(
         tester.element(find.byType(LoginPage)),
         listen: false);
+    final messageState = Provider.of<MessageState>(
+        tester.element(find.byType(LoginPage)),
+        listen: false);
     expect(appState.connected, true);
+    expect(messageState.messages.length, 2);
+    expect(
+        messageState.messages[0], {'text': 'Hello', 'is_user_message': false});
+    expect(
+        messageState.messages[1], {'text': 'Welcome', 'is_user_message': true});
   });
 
   testWidgets('Displays error message on failed connection',

--- a/ui/test/pages/login_page_test.mocks.dart
+++ b/ui/test/pages/login_page_test.mocks.dart
@@ -158,23 +158,6 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
-  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
-    String? url,
-    String? authToken,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #postRestartChat,
-          [
-            url,
-            authToken,
-          ],
-        ),
-        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
-            <Map<String, dynamic>>[]),
-      ) as _i4.Future<List<Map<String, dynamic>>>);
-
-  @override
   _i4.Future<Map<String, dynamic>> getConfig(
     String? url,
     String? authToken,
@@ -204,6 +187,23 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             url,
             authToken,
             config,
+          ],
+        ),
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
+
+  @override
+  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
+    String? url,
+    String? authToken,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postRestartChat,
+          [
+            url,
+            authToken,
           ],
         ),
         returnValue: _i4.Future<List<Map<String, dynamic>>>.value(

--- a/ui/test/pages/login_page_test.mocks.dart
+++ b/ui/test/pages/login_page_test.mocks.dart
@@ -141,7 +141,7 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<bool>);
 
   @override
-  _i4.Future<Map<String, dynamic>> getLoginResponse(
+  _i4.Future<List<Map<String, dynamic>>> getLoginResponse(
     String? url,
     String? authToken,
   ) =>
@@ -153,9 +153,26 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             authToken,
           ],
         ),
-        returnValue:
-            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i4.Future<Map<String, dynamic>>);
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
+
+  @override
+  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
+    String? url,
+    String? authToken,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postRestartChat,
+          [
+            url,
+            authToken,
+          ],
+        ),
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
   _i4.Future<Map<String, dynamic>> getConfig(
@@ -175,7 +192,7 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
-  _i4.Future<Map<String, dynamic>> updateConfig(
+  _i4.Future<List<Map<String, dynamic>>> updateConfig(
     String? url,
     String? authToken,
     Map<String, dynamic>? config,
@@ -189,9 +206,9 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             config,
           ],
         ),
-        returnValue:
-            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i4.Future<Map<String, dynamic>>);
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
   _i4.Future<Map<String, dynamic>> chat(

--- a/ui/test/state/message_state_test.dart
+++ b/ui/test/state/message_state_test.dart
@@ -23,6 +23,17 @@ void main() {
       expect(messageState.messages[0], newMessage);
     });
 
+    test('addMessages adds multiple messages', () {
+      final newMessages = [
+        {'text': 'Hello, world!', 'isUserMessage': true},
+        {'text': 'How are you?', 'isUserMessage': false},
+      ];
+      messageState.addMessages(newMessages);
+      expect(messageState.messages.length, 2);
+      expect(messageState.messages[0], newMessages[0]);
+      expect(messageState.messages[1], newMessages[1]);
+    });
+
     test('clearMessages clears all messages', () {
       final messages = [
         {'text': 'Message 1', 'isUserMessage': true},
@@ -48,13 +59,14 @@ void main() {
     });
 
     test('initialiseChat initializes the chat correctly', () {
-      final initialMessage = {
-        'text': 'Initial message',
-        'isUserMessage': false
-      };
-      messageState.initialiseChat(initialMessage);
-      expect(messageState.messages.length, 1);
-      expect(messageState.messages[0], initialMessage);
+      final initialMessages = [
+        {'text': 'Initial message 1', 'isUserMessage': false},
+        {'text': 'Initial message 2', 'isUserMessage': true},
+      ];
+      messageState.initialiseChat(initialMessages);
+      expect(messageState.messages.length, 2);
+      expect(messageState.messages[0], initialMessages[0]);
+      expect(messageState.messages[1], initialMessages[1]);
     });
   });
 }

--- a/ui/test/types_test.mocks.dart
+++ b/ui/test/types_test.mocks.dart
@@ -147,23 +147,6 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
-  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
-    String? url,
-    String? authToken,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #postRestartChat,
-          [
-            url,
-            authToken,
-          ],
-        ),
-        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
-            <Map<String, dynamic>>[]),
-      ) as _i4.Future<List<Map<String, dynamic>>>);
-
-  @override
   _i4.Future<Map<String, dynamic>> getConfig(
     String? url,
     String? authToken,
@@ -193,6 +176,23 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             url,
             authToken,
             config,
+          ],
+        ),
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
+
+  @override
+  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
+    String? url,
+    String? authToken,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postRestartChat,
+          [
+            url,
+            authToken,
           ],
         ),
         returnValue: _i4.Future<List<Map<String, dynamic>>>.value(

--- a/ui/test/types_test.mocks.dart
+++ b/ui/test/types_test.mocks.dart
@@ -130,7 +130,7 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<bool>);
 
   @override
-  _i4.Future<Map<String, dynamic>> getLoginResponse(
+  _i4.Future<List<Map<String, dynamic>>> getLoginResponse(
     String? url,
     String? authToken,
   ) =>
@@ -142,9 +142,26 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             authToken,
           ],
         ),
-        returnValue:
-            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i4.Future<Map<String, dynamic>>);
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
+
+  @override
+  _i4.Future<List<Map<String, dynamic>>> postRestartChat(
+    String? url,
+    String? authToken,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postRestartChat,
+          [
+            url,
+            authToken,
+          ],
+        ),
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
   _i4.Future<Map<String, dynamic>> getConfig(
@@ -164,7 +181,7 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
       ) as _i4.Future<Map<String, dynamic>>);
 
   @override
-  _i4.Future<Map<String, dynamic>> updateConfig(
+  _i4.Future<List<Map<String, dynamic>>> updateConfig(
     String? url,
     String? authToken,
     Map<String, dynamic>? config,
@@ -178,9 +195,9 @@ class MockHttpHelper extends _i1.Mock implements _i3.HttpHelper {
             config,
           ],
         ),
-        returnValue:
-            _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i4.Future<Map<String, dynamic>>);
+        returnValue: _i4.Future<List<Map<String, dynamic>>>.value(
+            <Map<String, dynamic>>[]),
+      ) as _i4.Future<List<Map<String, dynamic>>>);
 
   @override
   _i4.Future<Map<String, dynamic>> chat(
@@ -251,6 +268,15 @@ class MockMessageState extends _i1.Mock implements _i6.MessageState {
       );
 
   @override
+  void addMessages(List<Map<String, dynamic>>? messages) => super.noSuchMethod(
+        Invocation.method(
+          #addMessages,
+          [messages],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   void clearMessages() => super.noSuchMethod(
         Invocation.method(
           #clearMessages,
@@ -269,10 +295,11 @@ class MockMessageState extends _i1.Mock implements _i6.MessageState {
       );
 
   @override
-  void initialiseChat(Map<String, dynamic>? message) => super.noSuchMethod(
+  void initialiseChat(List<Map<String, dynamic>>? messages) =>
+      super.noSuchMethod(
         Invocation.method(
           #initialiseChat,
-          [message],
+          [messages],
         ),
         returnValueForMissingStub: null,
       );


### PR DESCRIPTION
This pull request introduces several significant changes to the `rpi_ai` project, focusing on enhancing chat history management and improving the chatbot's functionality. Key changes include the addition of a `MessageList` class for handling message lists, modifications to the chatbot's initialization and configuration processes, and updates to the test suite to accommodate these changes.

### Enhancements to Chat History Management:
* [`src/rpi_ai/api_types.py`](diffhunk://#diff-83cc9a8c386111ff4ec505c94f840fcf53ef6e1feef83844fc5c5830f768f097R34-R60): Introduced `MessageList` class to manage lists of `Message` objects, including methods for converting from a list of `Content` and retrieving chat history.
* [`src/rpi_ai/models/chatbot.py`](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL55-R60): Added `get_chat_history` method to retrieve the chat history and modified `start_chat` to initialize with a default message and history. [[1]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL55-R60) [[2]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fR70-L66)

### Chatbot Initialization and Configuration:
* [`src/rpi_ai/main.py`](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35R65): Added a new endpoint `/restart-chat` to restart the chat and retrieve the chat history. Updated existing endpoints to use `get_chat_history` instead of starting a new chat. [[1]](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35R65) [[2]](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35L124-R132) [[3]](diffhunk://#diff-f54afe99d1f0deaace554ceb8996911fe54940e3280e4bad023030a009346c35L136-R144)

### Test Suite Updates:
* [`tests/rpi_ai/conftest.py`](diffhunk://#diff-3af729e32e4270155008c31b1a85406218bdf36d989cc683c325746b68ef6f13R87-R92): Added a fixture `mock_get_chat_history` for mocking the `get_chat_history` method.
* [`tests/rpi_ai/models/test_chatbot.py`](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL46): Updated tests to remove calls to `start_chat` and verify `get_chat_history` instead. Added a new test for `get_chat_history`. [[1]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL46) [[2]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeR55-L64) [[3]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL73) [[4]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL84) [[5]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL98) [[6]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL114) [[7]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL130) [[8]](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL142)
* [`tests/rpi_ai/test_api_types.py`](diffhunk://#diff-93bf16f8a485f3fdb0ac8cc005d95e71ff03f978624be1d79be0929d801f4563L28-R54): Replaced tests for `Message` with tests for `MessageList`, including methods for converting from contents and retrieving history.
* [`tests/rpi_ai/test_main.py`](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L109-R116): Added tests for the new `/restart-chat` endpoint and updated existing tests to use `get_chat_history`. [[1]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L109-R116) [[2]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786R161) [[3]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L179-R181) [[4]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786R205-R231)

### UI Updates:
* [`ui/lib/components/app_bar/settings_dialog.dart`](diffhunk://#diff-6cd9e42bde9ad7ccd81d8d4682522dedd49ab19976f361ee671f99bca4e7590aL63-R71): Updated the settings dialog to handle the new chat history response format.
* [`ui/lib/helpers/http_helper.dart`](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50L45-R45): Modified the `getLoginResponse` method to return a list of messages instead of a single map.