### PR TITLE
Add error handling in MessageList.from_contents_list

### DIFF
--- a/src/rpi_ai/api_types.py
+++ b/src/rpi_ai/api_types.py
@@ -40,10 +40,13 @@ class MessageList:
     def from_contents_list(cls, contents: list[Content]) -> MessageList:
         message_list = cls([])
         for content in contents:
-            if content.role == "user":
-                message_list.add_user_message(content.parts[0].text.strip())
-            else:
-                message_list.add_model_message(content.parts[0].text.strip())
+            try:
+                if content.role == "user":
+                    message_list.add_user_message(content.parts[0].text.strip())
+                else:
+                    message_list.add_model_message(content.parts[0].text.strip())
+            except (AttributeError, IndexError):
+                pass
         return message_list
 
     @property

--- a/tests/rpi_ai/test_api_types.py
+++ b/tests/rpi_ai/test_api_types.py
@@ -29,12 +29,16 @@ class TestAIConfigType:
 # Chatbot responses
 class TestMessageList:
     def test_from_contents_list(self) -> None:
-        data = [
+        good_data = [
             Content(parts=[Part(text="user_msg")], role="user"),
             Content(parts=[Part(text="model_msg")], role="model"),
         ]
+        bad_data = [
+            Content(parts=[], role="user"),
+        ]
+        data = good_data + bad_data
         message_list = MessageList.from_contents_list(data)
-        assert len(message_list.messages) == len(data)
+        assert len(message_list.messages) == len(good_data)
         assert message_list.messages[0].message == "user_msg"
         assert message_list.messages[0].is_user_message
         assert message_list.messages[1].message == "model_msg"


### PR DESCRIPTION
This pull request includes changes to the `MessageList` class and its corresponding test to handle potential exceptions when processing content parts. The key changes are as follows:

Error handling improvements:

* [`src/rpi_ai/api_types.py`](diffhunk://#diff-83cc9a8c386111ff4ec505c94f840fcf53ef6e1feef83844fc5c5830f768f097R43-R49): Added a try-except block in the `from_contents_list` method to catch `AttributeError` and `IndexError` exceptions, ensuring that malformed content does not disrupt the message list creation.

Test updates:

* [`tests/rpi_ai/test_api_types.py`](diffhunk://#diff-93bf16f8a485f3fdb0ac8cc005d95e71ff03f978624be1d79be0929d801f4563L32-R41): Updated the `test_from_contents_list` method to include a test case for handling bad data (empty parts list), ensuring the method correctly processes only valid content.