### PR TITLE
Add persistent data

### DIFF
--- a/ui/lib/helpers/data_storage_helper.dart
+++ b/ui/lib/helpers/data_storage_helper.dart
@@ -1,0 +1,20 @@
+// Package imports:
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DataStorageHelper {
+  static Future<Map<String, dynamic>> loadAppState() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    String ip = prefs.getString('ip') ?? '127.0.0.1';
+    int port = prefs.getInt('port') ?? 5000;
+    String authToken = prefs.getString('authToken') ?? '';
+    return {'ip': ip, 'port': port, 'authToken': authToken};
+  }
+
+  static Future<void> saveAppState(
+      String ip, int port, String authToken) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setString('ip', ip);
+    await prefs.setInt('port', port);
+    await prefs.setString('authToken', authToken);
+  }
+}

--- a/ui/lib/pages/login_page.dart
+++ b/ui/lib/pages/login_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 // Project imports:
+import 'package:ui/helpers/data_storage_helper.dart';
 import 'package:ui/helpers/http_helper.dart';
 import 'package:ui/state/app_state.dart';
 import 'package:ui/state/message_state.dart';
@@ -40,9 +41,19 @@ class _LoginPageState extends State<LoginPage> {
     notificationState = Provider.of<NotificationState>(context, listen: false);
     settingsState = Provider.of<SettingsState>(context, listen: false);
     httpHelper = widget.httpHelper ?? HttpHelper();
+
     ipController = TextEditingController(text: appState.ip);
     portController = TextEditingController(text: appState.port.toString());
     authTokenController = TextEditingController(text: appState.authToken);
+
+    DataStorageHelper.loadAppState().then((Map<String, dynamic> data) {
+      appState.setIp(data['ip'] as String);
+      appState.setPort(data['port'] as int);
+      appState.setAuthToken(data['authToken'] as String);
+      ipController.text = appState.ip;
+      portController.text = appState.port.toString();
+      authTokenController.text = appState.authToken;
+    });
   }
 
   @override
@@ -108,6 +119,9 @@ class _LoginPageState extends State<LoginPage> {
               messageState.initialiseChat(messages);
               appState.setActivePage(PageType.text);
               notificationState.clearNotification();
+
+              await DataStorageHelper.saveAppState(
+                  appState.ip, appState.port, appState.authToken);
             }
           } catch (e) {
             notificationState.setNotificationError('Failed to connect: $e');

--- a/ui/pubspec.lock
+++ b/ui/pubspec.lock
@@ -632,6 +632,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.5"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   shelf:
     dependency: transitive
     description:

--- a/ui/pubspec.yaml
+++ b/ui/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   logging: ^1.2.0
+  shared_preferences: ^2.2.3
   permission_handler: ^11.0.1
   provider: ^6.0.0
   http: ^0.13.4

--- a/ui/test/helpers/data_storage_helper_test.dart
+++ b/ui/test/helpers/data_storage_helper_test.dart
@@ -1,0 +1,42 @@
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Project imports:
+import 'package:ui/helpers/data_storage_helper.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('saveAppState saves data correctly', () async {
+    SharedPreferences.setMockInitialValues({});
+    await DataStorageHelper.saveAppState('192.168.1.1', 8080, 'testToken');
+
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('ip'), '192.168.1.1');
+    expect(prefs.getInt('port'), 8080);
+    expect(prefs.getString('authToken'), 'testToken');
+  });
+
+  test('loadAppState loads data correctly', () async {
+    SharedPreferences.setMockInitialValues({
+      'ip': '192.168.1.1',
+      'port': 8080,
+      'authToken': 'testToken',
+    });
+
+    Map<String, dynamic> appState = await DataStorageHelper.loadAppState();
+    expect(appState['ip'], '192.168.1.1');
+    expect(appState['port'], 8080);
+    expect(appState['authToken'], 'testToken');
+  });
+
+  test('loadAppState returns default values when no data is saved', () async {
+    SharedPreferences.setMockInitialValues({});
+
+    Map<String, dynamic> appState = await DataStorageHelper.loadAppState();
+    expect(appState['ip'], '127.0.0.1');
+    expect(appState['port'], 5000);
+    expect(appState['authToken'], '');
+  });
+}


### PR DESCRIPTION
This pull request introduces a new helper class for managing app state persistence using shared preferences and integrates it into the login page. It also includes tests for the new functionality.

Key changes include:

### New Features:
* Added `DataStorageHelper` class to handle loading and saving app state using `shared_preferences` in `ui/lib/helpers/data_storage_helper.dart`.

### Integration:
* Integrated `DataStorageHelper` into `LoginPage` to load app state on initialization and save app state upon successful login in `ui/lib/pages/login_page.dart`. [[1]](diffhunk://#diff-2f385b377f6c440e53d123bee3a7c69e9c7b6fad37c1563d3174d4fc5e39c2bbR44-R56) [[2]](diffhunk://#diff-2f385b377f6c440e53d123bee3a7c69e9c7b6fad37c1563d3174d4fc5e39c2bbR122-R124)

### Dependency Updates:
* Added `shared_preferences` dependency in `ui/pubspec.yaml`.

### Testing:
* Added tests for `DataStorageHelper` to verify saving and loading of app state in `ui/test/helpers/data_storage_helper_test.dart`.