### PR TITLE
Update busy state management

### DIFF
--- a/ui/lib/components/conversation/text_input.dart
+++ b/ui/lib/components/conversation/text_input.dart
@@ -57,6 +57,7 @@ class _TextInputState extends State<TextInput> {
   }
 
   void sendMessage() async {
+    appState.setIsBusy(true);
     final String userMessage = textController.text.trim();
     if (userMessage.isEmpty) {
       return;
@@ -85,13 +86,13 @@ class _TextInputState extends State<TextInput> {
       messageType.handleFailedMessage(messageState);
       textController.text = userMessage;
       notificationState.setNotificationError('Failed to send message!');
-      return;
-    }
-
-    if (messageType == MessageType.text) {
+      appState.setIsBusy(false);
+    } else {
       messageState.addMessage(message);
       scrollToBottom();
     }
+
+    appState.setIsBusy(false);
   }
 
   @override

--- a/ui/lib/state/app_state.dart
+++ b/ui/lib/state/app_state.dart
@@ -35,13 +35,20 @@ class AppState extends ChangeNotifier {
     notifyListeners();
   }
 
+  void setActivePage(PageType newPage) {
+    if (!isBusy) {
+      _activePage = newPage;
+      notifyListeners();
+    }
+  }
+
   void setPageLogin() {
-    _activePage = PageType.login;
+    setActivePage(PageType.login);
     notifyListeners();
   }
 
   void setPageText() {
-    _activePage = PageType.text;
+    setActivePage(PageType.text);
     notifyListeners();
   }
 
@@ -51,7 +58,7 @@ class AppState extends ChangeNotifier {
   }
 
   void setPageSettings() {
-    _activePage = PageType.settings;
+    setActivePage(PageType.settings);
     notifyListeners();
   }
 

--- a/ui/test/state/app_state_test.dart
+++ b/ui/test/state/app_state_test.dart
@@ -42,6 +42,17 @@ void main() {
       expect(appState.connected, true);
     });
 
+    test('setActivePage sets the active page', () {
+      appState.setActivePage(PageType.text);
+      expect(appState.activePage, PageType.text);
+    });
+
+    test('setActivePage does not update the active page if busy', () {
+      appState.setIsBusy(true);
+      appState.setActivePage(PageType.text);
+      expect(appState.activePage, PageType.login);
+    });
+
     test('setPageLogin sets the active page to login', () {
       appState.setPageLogin();
       expect(appState.activePage, PageType.login);


### PR DESCRIPTION
This pull request includes several changes to the `ui/lib/components/conversation/text_input.dart` and `ui/lib/state/app_state.dart` files, as well as updates to the corresponding tests in `ui/test/state/app_state_test.dart`. The main focus is on improving state management and adding new functionality to the `AppState` class.

Improvements to state management:

* [`ui/lib/components/conversation/text_input.dart`](diffhunk://#diff-b021df796ecd9627bc135010ece769de9a9cac42f781279e7c6ec1ba47972a18R60): Added `appState.setIsBusy(true)` at the beginning of the `sendMessage` method and `appState.setIsBusy(false)` at the end to manage the busy state during message sending. [[1]](diffhunk://#diff-b021df796ecd9627bc135010ece769de9a9cac42f781279e7c6ec1ba47972a18R60) [[2]](diffhunk://#diff-b021df796ecd9627bc135010ece769de9a9cac42f781279e7c6ec1ba47972a18L88-R95)

Enhancements to `AppState` class:

* [`ui/lib/state/app_state.dart`](diffhunk://#diff-92e613c936b01b5e4b7ceb7a812edd3816580f55b65c78754f3ece7cd22d5163R38-R51): Introduced a new method `setActivePage` to update the active page only when the app is not busy. Updated the existing `setPageLogin`, `setPageText`, and `setPageSettings` methods to use `setActivePage`. [[1]](diffhunk://#diff-92e613c936b01b5e4b7ceb7a812edd3816580f55b65c78754f3ece7cd22d5163R38-R51) [[2]](diffhunk://#diff-92e613c936b01b5e4b7ceb7a812edd3816580f55b65c78754f3ece7cd22d5163L54-R61)

Updates to tests:

* [`ui/test/state/app_state_test.dart`](diffhunk://#diff-215909bfe89c244cce2fac011a16ba05eeb76b212923e77ab6d1c6fda05f00afR45-R55): Added tests for the new `setActivePage` method to ensure it sets the active page correctly and does not update the active page when the app is busy.