### PR TITLE
Add timestamp to message

### DIFF
--- a/src/rpi_ai/api_types.py
+++ b/src/rpi_ai/api_types.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from google.genai.types import Content, Part
 from pydantic.dataclasses import dataclass
 
@@ -7,19 +9,31 @@ from pydantic.dataclasses import dataclass
 @dataclass
 class Message:
     message: str
+    timestamp: int
     is_user_message: bool = False
 
     @classmethod
-    def user_message(cls, message: str) -> Message:
-        return cls(message=message, is_user_message=True)
+    def user_message(cls, message: str, timestamp: int) -> Message:
+        return cls(
+            message=message,
+            timestamp=timestamp,
+            is_user_message=True,
+        )
 
     @classmethod
-    def model_message(cls, message: str) -> Message:
-        return cls(message=message, is_user_message=False)
+    def model_message(cls, message: str, timestamp: int) -> Message:
+        return cls(
+            message=message,
+            timestamp=timestamp,
+            is_user_message=False,
+        )
 
     @classmethod
-    def new_chat_message(cls) -> Message:
-        return cls(message="What's on your mind today?")
+    def new_chat_message(cls, timestamp: int) -> Message:
+        return cls(
+            message="What's on your mind today?",
+            timestamp=timestamp,
+        )
 
 
 @dataclass
@@ -32,9 +46,9 @@ class MessageList:
         for content in contents:
             try:
                 if content.role == "user":
-                    msg = Message.user_message(content.parts[0].text.strip())
+                    msg = Message.user_message(content.parts[0].text.strip(), int(datetime.now().timestamp()))
                 else:
-                    msg = Message.model_message(content.parts[0].text.strip())
+                    msg = Message.model_message(content.parts[0].text.strip(), int(datetime.now().timestamp()))
 
                 msgs.append(msg)
             except (AttributeError, IndexError):
@@ -45,7 +59,10 @@ class MessageList:
     @property
     def as_contents_list(self) -> list[Content]:
         return [
-            Content(parts=[Part(text=message.message)], role="user" if message.is_user_message else "model")
+            Content(
+                parts=[Part(text=message.message)],
+                role="user" if message.is_user_message else "model",
+            )
             for message in self.messages
         ]
 
@@ -54,3 +71,4 @@ class MessageList:
 class SpeechResponse:
     bytes: str
     message: str
+    timestamp: int

--- a/src/rpi_ai/models/chatbot.py
+++ b/src/rpi_ai/models/chatbot.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from datetime import datetime
 from typing import ClassVar
 
 from google.genai import Client
@@ -99,7 +100,7 @@ class Chatbot:
         error_message = f"The previous message was blocked because it violates the following categories: {', '.join(blocked_categories)}."
         response = self._chat.send_message(error_message)
         reply = response.text
-        self._history.append(Message.model_message(reply))
+        self._history.append(Message.model_message(reply, int(datetime.now().timestamp())))
         return reply
 
     def get_config(self) -> ChatbotConfig:
@@ -109,7 +110,7 @@ class Chatbot:
         self._config = config
 
     def start_chat(self) -> None:
-        self._history = [Message.new_chat_message()]
+        self._history = [Message.new_chat_message(int(datetime.now().timestamp()))]
         self._chat = self._client.chats.create(
             model=self._config.model,
             config=self._chat_config,
@@ -118,10 +119,12 @@ class Chatbot:
 
     def send_message(self, text: str) -> Message:
         try:
+            user_message = Message.user_message(text, int(datetime.now().timestamp()))
+            self._history.append(user_message)
+
             response = self._chat.send_message(text)
-            self._history.append(Message.user_message(text))
-            self._history.append(Message.model_message(response.text))
-            return Message(message=response.text)
+            model_message = Message.model_message(response.text, int(datetime.now().timestamp()))
+            self._history.append(model_message)
         except (AttributeError, ValidationError) as e:
             msg = f"Failed to send message to chatbot: {e}"
             logger.exception(msg)
@@ -132,19 +135,25 @@ class Chatbot:
                 self._history.pop()
                 reply = "Failed to send message to chatbot!"
 
-            return Message(message=reply)
+            return Message(message=reply, timestamp=int(datetime.now().timestamp()))
         except ServerError:
-            return Message(message="Model overloaded! Please try again.")
+            self._history.pop()
+            return Message(message="Model overloaded! Please try again.", timestamp=int(datetime.now().timestamp()))
+        else:
+            return model_message
 
     def send_audio(self, audio_data: bytes) -> SpeechResponse:
         try:
             audio_request = audiobot.get_audio_request(audio_data)
+            user_message = Message.user_message(audio_request[0], int(datetime.now().timestamp()))
+            self._history.append(user_message)
+
             response = self._chat.send_message(audio_request)
-            reply = response.text
-            audio = audiobot.get_audio_bytes_from_text(reply.replace("*", ""))
-            self._history.append(Message.user_message(audio_request[0]))
-            self._history.append(Message.model_message(reply))
-            return SpeechResponse(bytes=audio, message=reply)
+            audio = audiobot.get_audio_bytes_from_text(response.text)
+            model_message = Message.model_message(response.text, int(datetime.now().timestamp()))
+            self._history.append(model_message)
+
+            return SpeechResponse(bytes=audio, message=response.text, timestamp=int(datetime.now().timestamp()))
         except (AttributeError, ValidationError) as e:
             msg = f"Failed to send audio to chatbot: {e}"
             logger.exception(msg)
@@ -156,12 +165,14 @@ class Chatbot:
                 reply = "Failed to send audio to chatbot!"
 
             audio = audiobot.get_audio_bytes_from_text(reply)
-            return SpeechResponse(bytes=audio, message=reply)
+            return SpeechResponse(bytes=audio, message=reply, timestamp=int(datetime.now().timestamp()))
         except ServerError:
+            self._history.pop()
             reply = "Model overloaded! Please try again."
             audio = audiobot.get_audio_bytes_from_text(reply)
-            return SpeechResponse(bytes=audio, message=reply)
+            return SpeechResponse(bytes=audio, message=reply, timestamp=int(datetime.now().timestamp()))
         except gTTSError as e:
+            self._history.pop()
             msg = f"A gTTSError occurred: {e}"
             logger.exception(msg)
-            return SpeechResponse(bytes="", message=str(e))
+            return SpeechResponse(bytes="", message=str(e), timestamp=int(datetime.now().timestamp()))

--- a/src/rpi_ai/models/chatbot.py
+++ b/src/rpi_ai/models/chatbot.py
@@ -149,10 +149,10 @@ class Chatbot:
             self._history.append(user_message)
 
             response = self._chat.send_message(audio_request)
-            audio = audiobot.get_audio_bytes_from_text(response.text)
             model_message = Message.model_message(response.text, int(datetime.now().timestamp()))
             self._history.append(model_message)
 
+            audio = audiobot.get_audio_bytes_from_text(response.text)
             return SpeechResponse(bytes=audio, message=response.text, timestamp=int(datetime.now().timestamp()))
         except (AttributeError, ValidationError) as e:
             msg = f"Failed to send audio to chatbot: {e}"
@@ -172,6 +172,7 @@ class Chatbot:
             audio = audiobot.get_audio_bytes_from_text(reply)
             return SpeechResponse(bytes=audio, message=reply, timestamp=int(datetime.now().timestamp()))
         except gTTSError as e:
+            self._history.pop()
             self._history.pop()
             msg = f"A gTTSError occurred: {e}"
             logger.exception(msg)

--- a/tests/rpi_ai/models/test_chatbot.py
+++ b/tests/rpi_ai/models/test_chatbot.py
@@ -215,7 +215,7 @@ class TestChatbot:
     def test_send_audio_with_gtts_error(
         self, mock_chatbot: Chatbot, mock_chat_instance: MagicMock, mock_get_audio_bytes_from_text: MagicMock
     ) -> None:
-        mock_chat_instance.send_message.return_value = MagicMock(parts=[MagicMock(text="Hi user!")])
+        mock_chat_instance.send_message.return_value = MagicMock(text="Hi user!")
         mock_get_audio_bytes_from_text.side_effect = gTTSError("gTTS error")
 
         response = mock_chatbot.send_audio(b"test_audio_data")

--- a/tests/rpi_ai/test_api_types.py
+++ b/tests/rpi_ai/test_api_types.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from google.genai.types import Content, Part
 
 from rpi_ai.api_types import Message, MessageList, SpeechResponse
@@ -5,18 +7,24 @@ from rpi_ai.api_types import Message, MessageList, SpeechResponse
 
 class TestMessage:
     def test_user_message(self) -> None:
-        message = Message.user_message("test_message")
+        timestamp = int(datetime.now().timestamp())
+        message = Message.user_message("test_message", timestamp)
         assert message.message == "test_message"
+        assert message.timestamp == timestamp
         assert message.is_user_message
 
     def test_model_message(self) -> None:
-        message = Message.model_message("test_message")
+        timestamp = int(datetime.now().timestamp())
+        message = Message.model_message("test_message", timestamp)
         assert message.message == "test_message"
+        assert message.timestamp == timestamp
         assert not message.is_user_message
 
     def test_new_chat_message(self) -> None:
-        message = Message.new_chat_message()
+        timestamp = int(datetime.now().timestamp())
+        message = Message.new_chat_message(timestamp)
         assert message.message == "What's on your mind today?"
+        assert message.timestamp == timestamp
         assert not message.is_user_message
 
 
@@ -53,7 +61,9 @@ class TestMessageList:
 
 class TestSpeechResponse:
     def test_from_dict(self) -> None:
-        data = {"message": "Hello, world!", "bytes": "audio_data"}
+        timestamp = int(datetime.now().timestamp())
+        data = {"bytes": "audio_data", "timestamp": timestamp, "message": "Hello, world!"}
         response = SpeechResponse(**data)
         assert response.message == "Hello, world!"
+        assert response.timestamp == timestamp
         assert response.bytes == "audio_data"

--- a/ui/lib/components/conversation/text_input.dart
+++ b/ui/lib/components/conversation/text_input.dart
@@ -67,8 +67,8 @@ class _TextInputState extends State<TextInput> {
 
     final Map<String, dynamic> userMessageDict = {
       'text': userMessage,
+      'timestamp': DateTime.now(),
       'isUserMessage': true,
-      'timestamp': DateTime.now()
     };
 
     messageType.handleAddMessage(messageState, userMessageDict);

--- a/ui/lib/components/messages/message_container.dart
+++ b/ui/lib/components/messages/message_container.dart
@@ -7,14 +7,14 @@ import 'package:ui/helpers/text_format_helper.dart';
 
 class MessageContainer extends StatelessWidget {
   final String message;
-  final bool isUserMessage;
   final DateTime timestamp;
+  final bool isUserMessage;
 
   const MessageContainer({
     Key? key,
     required this.message,
-    required this.isUserMessage,
     required this.timestamp,
+    required this.isUserMessage,
   }) : super(key: key);
 
   @override

--- a/ui/lib/components/messages/message_list.dart
+++ b/ui/lib/components/messages/message_list.dart
@@ -39,7 +39,7 @@ class _MessageListState extends State<MessageList> {
           return MessageContainer(
             message: message['text'],
             isUserMessage: message['isUserMessage'],
-            timestamp: DateTime.parse(message['timestamp'].toString()),
+            timestamp: message['timestamp'],
           );
         }
         return const SizedBox.shrink();

--- a/ui/lib/helpers/http_helper.dart
+++ b/ui/lib/helpers/http_helper.dart
@@ -55,8 +55,9 @@ class HttpHelper {
       return messages.map((message) {
         return {
           'text': message['message'].toString().trim(),
+          'timestamp': DateTime.fromMillisecondsSinceEpoch(
+              (message['timestamp'] * 1000).toInt()),
           'isUserMessage': message['is_user_message'],
-          'timestamp': DateTime.now(),
         };
       }).toList();
     }
@@ -102,8 +103,9 @@ class HttpHelper {
       return messages.map((message) {
         return {
           'text': message['message'].toString().trim(),
+          'timestamp': DateTime.fromMillisecondsSinceEpoch(
+              (message['timestamp'] * 1000).toInt()),
           'isUserMessage': message['is_user_message'],
-          'timestamp': DateTime.now(),
         };
       }).toList();
     }
@@ -126,8 +128,9 @@ class HttpHelper {
       return messages.map((message) {
         return {
           'text': message['message'].toString().trim(),
+          'timestamp': DateTime.fromMillisecondsSinceEpoch(
+              (message['timestamp'] * 1000).toInt()),
           'isUserMessage': message['is_user_message'],
-          'timestamp': DateTime.now(),
         };
       }).toList();
     }
@@ -158,8 +161,9 @@ class HttpHelper {
         final Map<String, dynamic> body = jsonDecode(response.body);
         return {
           'text': body['message'].toString().trim(),
+          'timestamp': DateTime.fromMillisecondsSinceEpoch(
+              (body['timestamp'] * 1000).toInt()),
           'isUserMessage': body['is_user_message'],
-          'timestamp': DateTime.now(),
         };
       }
 
@@ -200,6 +204,8 @@ class HttpHelper {
         final Map<String, dynamic> body = jsonDecode(response.body);
         return {
           'text': body['message'].toString().trim(),
+          'timestamp': DateTime.fromMillisecondsSinceEpoch(
+              (body['timestamp'] * 1000).toInt()),
           'bytes': body['bytes'],
         };
       }

--- a/ui/test/components/conversation/text_input_test.dart
+++ b/ui/test/components/conversation/text_input_test.dart
@@ -59,8 +59,8 @@ void main() {
     when(mockAppState.authToken).thenReturn('token');
     when(mockHttpHelper.chat(any, any, any)).thenAnswer((_) async => {
           'text': 'response',
+          'timestamp': DateTime.now(),
           'isUserMessage': false,
-          'timestamp': DateTime.now()
         });
 
     await tester.pumpWidget(createTextInput());
@@ -97,8 +97,8 @@ void main() {
     when(mockAppState.authToken).thenReturn('token');
     when(mockHttpHelper.chat(any, any, any)).thenAnswer((_) async => {
           'text': 'response',
+          'timestamp': DateTime.now(),
           'isUserMessage': false,
-          'timestamp': DateTime.now()
         });
 
     await tester

--- a/ui/test/components/messages/message_container_test.dart
+++ b/ui/test/components/messages/message_container_test.dart
@@ -17,8 +17,8 @@ void main() {
       home: Scaffold(
         body: MessageContainer(
           message: message,
-          isUserMessage: isUserMessage,
           timestamp: timestamp,
+          isUserMessage: isUserMessage,
         ),
       ),
     );
@@ -30,8 +30,8 @@ void main() {
     await tester.pumpWidget(
       createMessageContainer(
         message: 'Hello, this is a user message',
-        isUserMessage: true,
         timestamp: timestamp,
+        isUserMessage: true,
       ),
     );
 
@@ -60,8 +60,8 @@ void main() {
     await tester.pumpWidget(
       createMessageContainer(
         message: 'Hello, this is a non-user message',
-        isUserMessage: false,
         timestamp: timestamp,
+        isUserMessage: false,
       ),
     );
 
@@ -92,8 +92,8 @@ void main() {
       createMessageContainer(
         message:
             'This is **bold** text\n* Bullet point 1\n* Bullet point 2\nThis is ***bold and italic*** text',
-        isUserMessage: true,
         timestamp: timestamp,
+        isUserMessage: true,
       ),
     );
 

--- a/ui/test/components/messages/message_list_test.dart
+++ b/ui/test/components/messages/message_list_test.dart
@@ -27,13 +27,13 @@ void main() {
     final messages = [
       {
         'text': 'Hello, this is a user message',
-        'isUserMessage': true,
         'timestamp': timestamp,
+        'isUserMessage': true,
       },
       {
         'text': 'Hello, this is a non-user message',
-        'isUserMessage': false,
         'timestamp': timestamp,
+        'isUserMessage': false,
       },
     ];
 
@@ -67,8 +67,8 @@ void main() {
         20,
         (index) => {
               'text': 'Message $index',
-              'isUserMessage': index % 2 == 0,
               'timestamp': DateTime.now(),
+              'isUserMessage': index % 2 == 0,
             });
     final scrollController = ScrollController();
 

--- a/ui/test/helpers/http_helper_test.dart
+++ b/ui/test/helpers/http_helper_test.dart
@@ -90,8 +90,16 @@ void main() {
     )).thenAnswer((_) async => http.Response(
         jsonEncode({
           'messages': [
-            {'message': 'Welcome', 'is_user_message': true},
-            {'message': 'Hello', 'is_user_message': false}
+            {
+              'message': 'Welcome',
+              'timestamp': 1678886400,
+              'is_user_message': true,
+            },
+            {
+              'message': 'Hello',
+              'timestamp': 1678886460,
+              'is_user_message': false,
+            }
           ]
         }),
         200));
@@ -100,13 +108,13 @@ void main() {
     expect(messages.length, 2);
     expect(messages[0], {
       'text': 'Welcome',
-      'isUserMessage': true,
       'timestamp': isA<DateTime>(),
+      'isUserMessage': true,
     });
     expect(messages[1], {
       'text': 'Hello',
-      'isUserMessage': false,
       'timestamp': isA<DateTime>(),
+      'isUserMessage': false,
     });
   });
 
@@ -190,6 +198,7 @@ void main() {
           'messages': [
             {
               'message': 'Config updated successfully',
+              'timestamp': 1678886400,
               'is_user_message': false
             },
           ]
@@ -199,8 +208,8 @@ void main() {
     final messages = await httpHelper.updateConfig(uri, authToken, config);
     expect(messages[0], {
       'text': 'Config updated successfully',
-      'isUserMessage': false,
       'timestamp': isA<DateTime>(),
+      'isUserMessage': false,
     });
   });
 
@@ -243,7 +252,11 @@ void main() {
     )).thenAnswer((_) async => http.Response(
         jsonEncode({
           'messages': [
-            {'message': 'Chat restarted', 'is_user_message': false},
+            {
+              'message': 'Chat restarted',
+              'timestamp': 1678886400,
+              'is_user_message': false,
+            },
           ]
         }),
         200));
@@ -252,8 +265,8 @@ void main() {
     expect(messages.length, 1);
     expect(messages[0], {
       'text': 'Chat restarted',
-      'isUserMessage': false,
       'timestamp': isA<DateTime>(),
+      'isUserMessage': false,
     });
   });
 
@@ -288,12 +301,17 @@ void main() {
       },
       body: jsonEncode({'message': message}),
     )).thenAnswer((_) async => http.Response(
-        jsonEncode({'message': 'Hi', 'is_user_message': false}), 200));
+        jsonEncode({
+          'message': 'Hi',
+          'timestamp': 1678886400,
+          'is_user_message': false,
+        }),
+        200));
 
     expect(await httpHelper.chat(uri, authToken, message), {
       'text': 'Hi',
-      'isUserMessage': false,
       'timestamp': isA<DateTime>(),
+      'isUserMessage': false,
     });
   });
 


### PR DESCRIPTION
This pull request introduces several changes to add timestamps to messages and improve the handling of message history in both the backend and frontend. The changes include modifications to the `Message` class, updates to various methods to include timestamps, and adjustments to the frontend components to handle the new timestamp data.

Backend changes:

* [`src/rpi_ai/api_types.py`](diffhunk://#diff-83cc9a8c386111ff4ec505c94f840fcf53ef6e1feef83844fc5c5830f768f097R3-R36): Added a `timestamp` field to the `Message` class and updated the `user_message`, `model_message`, and `new_chat_message` methods to include the timestamp parameter. Updated the `from_contents_list` and `as_contents_list` methods to handle timestamps. [[1]](diffhunk://#diff-83cc9a8c386111ff4ec505c94f840fcf53ef6e1feef83844fc5c5830f768f097R3-R36) [[2]](diffhunk://#diff-83cc9a8c386111ff4ec505c94f840fcf53ef6e1feef83844fc5c5830f768f097L35-R51) [[3]](diffhunk://#diff-83cc9a8c386111ff4ec505c94f840fcf53ef6e1feef83844fc5c5830f768f097L48-R65) [[4]](diffhunk://#diff-83cc9a8c386111ff4ec505c94f840fcf53ef6e1feef83844fc5c5830f768f097R74)
* [`src/rpi_ai/models/chatbot.py`](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fR2): Updated methods such as `_handle_blocked_message`, `start_chat`, `send_message`, and `send_audio` to include timestamps when creating `Message` instances. [[1]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fR2) [[2]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL102-R103) [[3]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL112-R113) [[4]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fR122-R127) [[5]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL135-R156) [[6]](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL159-R179)

Frontend changes:

* [`ui/lib/components/conversation/text_input.dart`](diffhunk://#diff-b021df796ecd9627bc135010ece769de9a9cac42f781279e7c6ec1ba47972a18R70-L71): Added a timestamp to the user message dictionary.
* [`ui/lib/components/messages/message_container.dart`](diffhunk://#diff-29fb457b1a8ce362e0248b3b29cdb0e8141d6128dc3c886f9f9ae93767718becL10-R17): Adjusted the order of parameters in the `MessageContainer` constructor to include the timestamp.
* [`ui/lib/components/messages/message_list.dart`](diffhunk://#diff-c7ead6b1f726e13249a9b4b99abd536cb2ca30d26134958dbff57004aab4a93aL42-R42): Updated the `MessageContainer` instantiation to use the correct timestamp.
* [`ui/lib/helpers/http_helper.dart`](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50R58-L59): Modified methods to convert timestamps from the backend to `DateTime` objects. [[1]](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50R58-L59) [[2]](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50R106-L106) [[3]](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50R131-L130) [[4]](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50R164-L162) [[5]](diffhunk://#diff-7b993342ae4047cbd34cd649eb324b04c5533b169f000f6c946f905061677f50R207-R208)

Test updates:

* [`tests/rpi_ai/test_api_types.py`](diffhunk://#diff-93bf16f8a485f3fdb0ac8cc005d95e71ff03f978624be1d79be0929d801f4563R1-R27): Updated tests to include timestamp checks for `Message` and `SpeechResponse` instances. [[1]](diffhunk://#diff-93bf16f8a485f3fdb0ac8cc005d95e71ff03f978624be1d79be0929d801f4563R1-R27) [[2]](diffhunk://#diff-93bf16f8a485f3fdb0ac8cc005d95e71ff03f978624be1d79be0929d801f4563L56-R68)
* [`ui/test/components/conversation/text_input_test.dart`](diffhunk://#diff-f37b89551757950170daa11193e38ad5daf73ead995921cb56fa13d4297c9f32R62-L63): Adjusted mock responses to include timestamps. [[1]](diffhunk://#diff-f37b89551757950170daa11193e38ad5daf73ead995921cb56fa13d4297c9f32R62-L63) [[2]](diffhunk://#diff-f37b89551757950170daa11193e38ad5daf73ead995921cb56fa13d4297c9f32R100-L101)
* [`ui/test/components/messages/message_container_test.dart`](diffhunk://#diff-2acb2e1d487388d36aa40c610d87db189ab3d8f8c218f082fff49a58ad7f191aL20-R21): Updated tests to handle the new timestamp parameter. [[1]](diffhunk://#diff-2acb2e1d487388d36aa40c610d87db189ab3d8f8c218f082fff49a58ad7f191aL20-R21) [[2]](diffhunk://#diff-2acb2e1d487388d36aa40c610d87db189ab3d8f8c218f082fff49a58ad7f191aL33-R34) [[3]](diffhunk://#diff-2acb2e1d487388d36aa40c610d87db189ab3d8f8c218f082fff49a58ad7f191aL63-R64) [[4]](diffhunk://#diff-2acb2e1d487388d36aa40c610d87db189ab3d8f8c218f082fff49a58ad7f191aL95-R96)
* [`ui/test/components/messages/message_list_test.dart`](diffhunk://#diff-94e476c0fafe5bb50533126ea5322a02559b21204ecf7d5f96d49d8dbf39ef46L30-R36): Adjusted test data to include timestamps. [[1]](diffhunk://#diff-94e476c0fafe5bb50533126ea5322a02559b21204ecf7d5f96d49d8dbf39ef46L30-R36) [[2]](diffhunk://#diff-94e476c0fafe5bb50533126ea5322a02559b21204ecf7d5f96d49d8dbf39ef46L70-R71)