### PR TITLE
Remove history parameter from Chatbot and TestChatbot classes

### DIFF
--- a/src/rpi_ai/models/chatbot.py
+++ b/src/rpi_ai/models/chatbot.py
@@ -114,7 +114,6 @@ class Chatbot:
         self._chat = self._client.chats.create(
             model=self._config.model,
             config=self._chat_config,
-            history=self.chat_history.as_contents_list,
         )
 
     def send_message(self, text: str) -> Message:

--- a/tests/rpi_ai/models/test_chatbot.py
+++ b/tests/rpi_ai/models/test_chatbot.py
@@ -91,7 +91,6 @@ class TestChatbot:
                 candidate_count=1,
                 tools=mock_chatbot._functions,
             ),
-            history=mock_chatbot.chat_history.as_contents_list,
         )
         assert len(mock_chatbot.chat_history.messages) == 1
 


### PR DESCRIPTION
This pull request includes changes to the `src/rpi_ai/models/chatbot.py` and `tests/rpi_ai/models/test_chatbot.py` files to remove the history parameter when creating a chat. The most important changes include modifying the `start_chat` method and updating the corresponding test to reflect this change.

Changes to `start_chat` method:

* [`src/rpi_ai/models/chatbot.py`](diffhunk://#diff-b66f439e32b49006394665fc8385a9a0750e092d2fc3d61195465ae1da24ab9fL117): Removed the `history` parameter from the `self._client.chats.create` method call in the `start_chat` method.

Updates to tests:

* [`tests/rpi_ai/models/test_chatbot.py`](diffhunk://#diff-e911c1d953abee2201e685956dff684234e06a6fd509024c164b2de8d7322afeL94): Removed the `history` parameter from the `mock_genai_client.chats.create` method call in the `test_start_chat` test method.