### PR TITLE
Refactor JSON response handling to use model_dump for consistent output

### DIFF
--- a/rpi_ai/main.py
+++ b/rpi_ai/main.py
@@ -119,7 +119,7 @@ class AIApp:
         logger.info("Starting new chat...")
         response = self.chatbot.chat_history
         logger.info("Loaded chat history: %s messages", len(response.messages))
-        return jsonify(response)
+        return jsonify(response.model_dump())
 
     def restart_chat(self) -> Response:
         """Restart chat session endpoint.
@@ -130,7 +130,7 @@ class AIApp:
         logger.info("Restarting chat...")
         self.chatbot.start_chat()
         response = self.chatbot.chat_history
-        return jsonify(response)
+        return jsonify(response.model_dump())
 
     def get_config(self) -> Response:
         """Get chatbot configuration endpoint.
@@ -152,7 +152,7 @@ class AIApp:
         config.save(self.config.config_file)
         self.chatbot.start_chat()
         response = self.chatbot.chat_history
-        return jsonify(response)
+        return jsonify(response.model_dump())
 
     def chat(self) -> Response:
         """Chat message endpoint.
@@ -171,7 +171,7 @@ class AIApp:
                 timestamp=int(datetime.now().timestamp()),
             )
             logger.error(response.message)
-        return jsonify(response)
+        return jsonify(response.model_dump())
 
     def send_audio(self) -> Response:
         """Audio message endpoint.
@@ -192,7 +192,7 @@ class AIApp:
                 timestamp=int(datetime.now().timestamp()),
             )
             logger.error(response.message)
-        return jsonify(response)
+        return jsonify(response.model_dump())
 
     def shutdown_handler(self, signum: int, frame: FrameType | None) -> None:
         """Handle shutdown signal.

--- a/tests/rpi_ai/test_main.py
+++ b/tests/rpi_ai/test_main.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 from flask.testing import FlaskClient
 
-from rpi_ai.api_types import Message, SpeechResponse
 from rpi_ai.config import ChatbotConfig
 from rpi_ai.main import AIApp, main
 
@@ -48,7 +47,7 @@ class TestAIApp:
         mock_request_headers.return_value = {"Authorization": mock_generate_token.return_value}
         response = mock_client.get("/login")
         mock_chat_history.assert_called_once()
-        mock_jsonify.assert_called_once_with(mock_chat_history.return_value)
+        mock_jsonify.assert_called_once_with(mock_chat_history.return_value.model_dump())
         assert response.status_code == SUCCESS_CODE
 
     def test_login_unauthorized(
@@ -115,7 +114,7 @@ class TestAIApp:
         mock_update_config.assert_called_once_with(ChatbotConfig.model_validate(new_config))
         mock_save_config.assert_called_once()
         mock_start_chat.assert_called_once()
-        mock_jsonify.assert_called_once_with(mock_chat_history.return_value)
+        mock_jsonify.assert_called_once_with(mock_chat_history.return_value.model_dump())
         assert response.status_code == SUCCESS_CODE
 
     def test_update_config_unauthorized(
@@ -152,7 +151,7 @@ class TestAIApp:
         mock_request_headers.return_value = {"Authorization": mock_generate_token.return_value}
         response = mock_client.post("/restart-chat")
         mock_start_chat.assert_called_once()
-        mock_jsonify.assert_called_once_with(mock_chat_history.return_value)
+        mock_jsonify.assert_called_once_with(mock_chat_history.return_value.model_dump())
         assert response.status_code == SUCCESS_CODE
 
     def test_restart_chat_unauthorized(
@@ -183,7 +182,7 @@ class TestAIApp:
 
         response = mock_client.post("/chat")
         mock_send_message.assert_called_once_with(user_message)
-        mock_jsonify.assert_called_once_with(mock_send_message.return_value)
+        mock_jsonify.assert_called_once_with(mock_send_message.return_value.model_dump())
         assert response.status_code == SUCCESS_CODE
 
     def test_chat_unauthorized(
@@ -220,10 +219,10 @@ class TestAIApp:
         call_args = mock_jsonify.call_args
         assert call_args is not None
         arg = call_args[0][0]
-        assert isinstance(arg, Message)
-        assert arg.message == "No message received."
-        assert arg.is_user_message is False
-        assert isinstance(arg.timestamp, int)
+        assert isinstance(arg, dict)
+        assert arg["message"] == "No message received."
+        assert arg["is_user_message"] is False
+        assert isinstance(arg["timestamp"], int)
         assert response.status_code == SUCCESS_CODE
 
     def test_send_audio(
@@ -241,7 +240,7 @@ class TestAIApp:
 
         response = mock_client.post("/send-audio")
         mock_send_audio.assert_called_once_with("audio_data")
-        mock_jsonify.assert_called_once_with(mock_send_audio.return_value)
+        mock_jsonify.assert_called_once_with(mock_send_audio.return_value.model_dump())
         assert response.status_code == SUCCESS_CODE
 
     def test_send_audio_unauthorized(
@@ -277,10 +276,10 @@ class TestAIApp:
         call_args = mock_jsonify.call_args
         assert call_args is not None
         arg = call_args[0][0]
-        assert isinstance(arg, SpeechResponse)
-        assert arg.message == "No audio data received."
-        assert arg.bytes == ""
-        assert isinstance(arg.timestamp, int)
+        assert isinstance(arg, dict)
+        assert arg["message"] == "No audio data received."
+        assert arg["bytes"] == ""
+        assert isinstance(arg["timestamp"], int)
         assert response.status_code == SUCCESS_CODE
 
     def test_run_with_waitress(self, mock_ai_app: AIApp, mock_waitress_serve: MagicMock) -> None:


### PR DESCRIPTION
This pull request updates the API response serialization in the `rpi_ai/main.py` endpoints to consistently use the `model_dump()` method before passing objects to `jsonify`. Corresponding changes were made in the test suite to reflect this new behavior, ensuring that tests expect dictionary responses rather than model instances.

**API response serialization improvements:**

* All endpoints in `rpi_ai/main.py` now return `jsonify(response.model_dump())` instead of `jsonify(response)`, ensuring that Pydantic models are properly converted to dictionaries before serialization. [[1]](diffhunk://#diff-25b1ebe101b96882e8e5c5cb630953405b7ea493abcff292fac05d29122172b1L122-R122) [[2]](diffhunk://#diff-25b1ebe101b96882e8e5c5cb630953405b7ea493abcff292fac05d29122172b1L133-R133) [[3]](diffhunk://#diff-25b1ebe101b96882e8e5c5cb630953405b7ea493abcff292fac05d29122172b1L155-R155) [[4]](diffhunk://#diff-25b1ebe101b96882e8e5c5cb630953405b7ea493abcff292fac05d29122172b1L174-R174) [[5]](diffhunk://#diff-25b1ebe101b96882e8e5c5cb630953405b7ea493abcff292fac05d29122172b1L195-R195)

**Test suite updates:**

* Test assertions in `tests/rpi_ai/test_main.py` now expect `jsonify` to be called with the result of `.model_dump()` rather than the raw model instances. [[1]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L51-R50) [[2]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L118-R117) [[3]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L155-R154) [[4]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L186-R185) [[5]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L244-R243)
* Tests for error cases (`test_chat_no_message`, `test_send_audio_no_audio`) now check for dictionary contents instead of model attributes, reflecting the new response format. [[1]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L223-R225) [[2]](diffhunk://#diff-253cff3d7374bf98382007ef62d3832ffcc8df935182fb25b22514e103fad786L280-R282)

**Code cleanup:**

* Removed unused imports from `tests/rpi_ai/test_main.py` to tidy up the test code.