### PR TITLE
Update JSON response configuration and fastapi version in lock file

### DIFF
--- a/configuration/config.json
+++ b/configuration/config.json
@@ -18,6 +18,12 @@
     "ssl_certfile": "cert.pem",
     "days_valid": 365
   },
+  "json_response": {
+    "ensure_ascii": false,
+    "allow_nan": false,
+    "indent": null,
+    "media_type": "application/json; charset=utf-8"
+  },
   "chatbot_config": {
     "model": "gemini-2.0-flash",
     "system_instruction": "You are a friendly AI assistant. You are designed to help the user with daily tasks.",

--- a/uv.lock
+++ b/uv.lock
@@ -339,7 +339,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.123.0"
+version = "0.123.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -347,9 +347,9 @@ dependencies = [
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/c7/d3956d7c2da2b66188eacc8db0919635b28313a30334dd78cba4c366caf0/fastapi-0.123.0.tar.gz", hash = "sha256:1410678b3c44418245eec85088b15140d894074b86e66061017e2b492c09b138", size = 347702, upload-time = "2025-11-30T14:49:17.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/b8/c6e916565af8a8e1c8f5a4736b31a6995adb51dbd4cbefc8b022e753ecb9/fastapi-0.123.5.tar.gz", hash = "sha256:54bbb660ca231d3985474498b51c621ddcf8888d9a4c1ecb10aa40ec217e4965", size = 352030, upload-time = "2025-12-02T21:08:38.532Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/17/62c82beab6536ea72576f90b84a3dbe6bcceb88d3d46afc4d05c376f0231/fastapi-0.123.0-py3-none-any.whl", hash = "sha256:cb56e69e874afa897bd3416c8a3dbfdae1730d0a308d4c63303f3f4b44136ae4", size = 110865, upload-time = "2025-11-30T14:49:16.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/dc/faa52fe784892bb057934248ded02705d26ca3aca562876e61c239947036/fastapi-0.123.5-py3-none-any.whl", hash = "sha256:a9c708e47c0fa424139cddb8601d0f92d3111b77843c22e9c8d0164d65fe3c97", size = 111316, upload-time = "2025-12-02T21:08:36.191Z" },
 ]
 
 [[package]]
@@ -960,7 +960,7 @@ wheels = [
 [[package]]
 name = "python-template-server"
 version = "0.1.0"
-source = { git = "https://github.com/javidahmed64592/python-template-server.git#b14f0b36196dbd4f183b25597e7cd4f8ccdbed69" }
+source = { git = "https://github.com/javidahmed64592/python-template-server.git#aee26bd2909c639ceb58e778d96ce319862a3a1b" }
 dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },


### PR DESCRIPTION
This pull request adds a new `json_response` configuration section to `configuration/config.json` to provide more control over JSON response formatting and media type settings.

Configuration enhancements:

* Added a `json_response` section with options for `ensure_ascii`, `allow_nan`, `indent`, and `media_type` to allow more flexible and standards-compliant JSON output.