### PR TITLE
Return response from memory creation function

### DIFF
--- a/rpi_ai/chatbot.py
+++ b/rpi_ai/chatbot.py
@@ -155,16 +155,19 @@ class Chatbot:
             raise AttributeError(msg)
         return np.array(embedding_response.embeddings[0].values)
 
-    def create_memory(self, text: str) -> None:
+    def create_memory(self, text: str) -> str:
         """Create a persistent chat memory.
 
         :param str text:
             Memory text to store
+        :return str:
+            Confirmation message
         """
         vector = self._embed_text(text, task_type="SEMANTIC_SIMILARITY")
         self._memory.add_entry(text=text, vector=vector.tolist(), max_memories=self._embedding_config.max_memories)
         self._memory.save_to_file(self._config_dir / self._embedding_config.memory_filepath)
         logger.info("Stored new memory (%d entries): %s", len(self._memory.entries), text)
+        return f"Memory stored successfully: {text}"
 
     def retrieve_memories(self, query: str) -> list[str]:
         """Retrieve relevant memories based on the query.

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -93,7 +93,8 @@ class TestChatbot:
         initial_count = len(mock_chatbot._memory.entries)
         memory_text = "New memory"
 
-        mock_chatbot.create_memory(memory_text)
+        response = mock_chatbot.create_memory(memory_text)
+        assert response == f"Memory stored successfully: {memory_text}"
 
         assert len(mock_chatbot._memory.entries) == initial_count + 1
         assert mock_chatbot._memory.entries[-1].text == memory_text


### PR DESCRIPTION
This pull request updates the chat memory creation workflow to provide clearer feedback when storing a new memory. The main change is that the `create_memory` method now returns a confirmation message, and the corresponding test has been updated to verify this behavior.

Improvements to chat memory feedback:

* Changed the `create_memory` method in `chatbot.py` to return a confirmation message after storing a new memory, instead of returning nothing.
* Updated the test in `test_chatbot.py` to assert that the confirmation message is returned when a new memory is created.